### PR TITLE
ショップ検索画面の作成

### DIFF
--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::ShopsController < ApplicationController
+  require "net/http"
+  require "uri"
+  require "cgi"
+
+  def search
+    query = CGI.escape("芋のお菓子専門店+in+#{params[:location]}")
+    uri = URI.parse("https://maps.googleapis.com/maps/api/place/textsearch/json?query=#{query}&key=#{ENV['GOOGLE_MAP_API_KEY']}")
+    res = Net::HTTP.get_response(uri)
+    render json: res.body
+  end
+end

--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::ShopsController < ApplicationController
 
   def search
     query = CGI.escape("芋のお菓子専門店+in+#{params[:location]}")
-    uri = URI.parse("https://maps.googleapis.com/maps/api/place/textsearch/json?query=#{query}&key=#{ENV['GOOGLE_MAP_API_KEY']}")
+    uri = URI.parse("https://maps.googleapis.com/maps/api/place/textsearch/json?query=#{query}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
     res = Net::HTTP.get_response(uri)
     render json: res.body
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
       namespace :auth do
         resources :sessions, only: %i[index]
       end
+
+      get 'shops/search', to: 'shops#search'
     end
   end
 end

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.45.0",
+        "react-icons": "^4.10.1",
         "react-router-dom": "^6.14.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -14547,6 +14548,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.1.1",
+        "@react-google-maps/api": "^2.18.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2421,6 +2422,23 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
+      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.0.15.tgz",
+      "integrity": "sha512-/I6Esi5FtyeVHsezN9Kut8zRJoqe7KkTIJXGVqpKFf6BjC7qQ1xRajLMkOz0s8XKgLevbr+KdYjuvmj+LohOGg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "supercluster": "^7.1.3"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.1.1.tgz",
@@ -3293,6 +3311,33 @@
         }
       }
     },
+    "node_modules/@react-google-maps/api": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.18.1.tgz",
+      "integrity": "sha512-KVlUO/Shh+0g/3egWaKmY0sz6+0QOnYkBGvrBMJbz23519LauA+iJFc4NDCmWNHqD5Vhb/Bkg0kSJgq0Stz3Iw==",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "1.15.1",
+        "@googlemaps/markerclusterer": "2.0.15",
+        "@react-google-maps/infobox": "2.16.0",
+        "@react-google-maps/marker-clusterer": "2.16.1",
+        "@types/google.maps": "3.50.5",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/@react-google-maps/infobox": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.16.0.tgz",
+      "integrity": "sha512-ZojiMS25388RcUHQPycUAerSqdHDom+3dHczVcXHdT/i8fka3O8InkHxXwMhvBoM143ips7mv2BPaYOAJ5f4Nw=="
+    },
+    "node_modules/@react-google-maps/marker-clusterer": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.16.1.tgz",
+      "integrity": "sha512-jOuyqzWLeXvQcoAu6TCVWHAuko+sDt0JjawNHBGqUNLywMtTCvYP0L0PiqJZOUCUeRYGdUy0AKxQ+30vAkvwag=="
+    },
     "node_modules/@remix-run/router": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.0.tgz",
@@ -4057,6 +4102,11 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.50.5",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.50.5.tgz",
+      "integrity": "sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -9168,6 +9218,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
@@ -11777,6 +11835,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -15796,6 +15859,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "dependencies": {
+        "kdbush": "^3.0.0"
       }
     },
     "node_modules/supports-color": {

--- a/front/package.json
+++ b/front/package.json
@@ -19,6 +19,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.0",
+    "react-icons": "^4.10.1",
     "react-router-dom": "^6.14.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/front/package.json
+++ b/front/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@hookform/resolvers": "^3.1.1",
+    "@react-google-maps/api": "^2.18.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -9,11 +9,14 @@ import TopPage from "./components/TopPage/TopPage";
 import { getCurrentUser } from "./lib/api/auth";
 import { AuthProvider, useAuthContext } from "./context/AuthContext";
 import ShopSearch from "./components/ShopSearch/ShopSearch";
+import { ShopProvider } from "./context/ShopContext";
 
 const App = () => {
   return (
     <AuthProvider>
-      <AppContent />
+      <ShopProvider>
+        <AppContent />
+      </ShopProvider>
     </AuthProvider>
   );
 };

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -8,6 +8,7 @@ import Register from "./components/Register/Register";
 import TopPage from "./components/TopPage/TopPage";
 import { getCurrentUser } from "./lib/api/auth";
 import { AuthProvider, useAuthContext } from "./context/AuthContext";
+import ShopSearch from "./components/ShopSearch/ShopSearch";
 
 const App = () => {
   return (
@@ -46,6 +47,7 @@ const AppContent = () => {
         <Route path="/" element={<TopPage />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/shop-search" element={<ShopSearch />} />
       </Routes>
     </Router>
   );

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { GoogleMap as GoogleMapComponent, LoadScript, MarkerF } from "@react-google-maps/api";
+import { GoogleMap as GoogleMapComponent, Marker, useJsApiLoader } from "@react-google-maps/api";
 
 type CenterType = {
   lat: number;
@@ -11,24 +11,29 @@ type ContentStyleType = {
   height: string;
 };
 
+const containerStyle: ContentStyleType = {
+  width: "100%",
+  height: "100%",
+};
+
+// とりあえず名古屋城を中心に表示
+const center: CenterType = {
+  lat: 35.182253007459444,
+  lng: 136.90534328438358,
+};
+
 const GoogleMap: FC = () => {
-  const containerStyle: ContentStyleType = {
-    width: "100%",
-    height: "100%",
-  };
+  const { isLoaded } = useJsApiLoader({
+    id: "google-map-script",
+    googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || "",
+  });
 
-  // とりあえず名古屋城を中心に表示
-  const center: CenterType = {
-    lat: 35.182253007459444,
-    lng: 136.90534328438358,
-  };
-
-  return (
-    <LoadScript googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAP_API_KEY || ""}>
-      <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={15}>
-        <MarkerF position={center} />
-      </GoogleMapComponent>
-    </LoadScript>
+  return isLoaded ? (
+    <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={15}>
+      <Marker position={center} />
+    </GoogleMapComponent>
+  ) : (
+    <></>
   );
 };
 

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from "react";
 import { GoogleMap as GoogleMapComponent, Marker, useJsApiLoader } from "@react-google-maps/api";
 
-import { GoogleMapCenterType, ShopType } from "../../types";
+import { GoogleMapCenterType } from "../../types";
+import { useShopContext } from "../../context/ShopContext";
 
 type Props = {
   center: GoogleMapCenterType;
-  shops: ShopType[];
 };
 
 type ContentStyleType = {
@@ -18,11 +18,13 @@ const containerStyle: ContentStyleType = {
   height: "100%",
 };
 
-const GoogleMap: FC<Props> = ({ center, shops }) => {
+const GoogleMap: FC<Props> = ({ center }) => {
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || "",
   });
+
+  const { shops } = useShopContext();
 
   return isLoaded ? (
     <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={11}>

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from "react";
+import { GoogleMap as GoogleMapComponent, LoadScript, MarkerF } from "@react-google-maps/api";
+
+type CenterType = {
+  lat: number;
+  lng: number;
+};
+
+type ContentStyleType = {
+  width: string;
+  height: string;
+};
+
+const GoogleMap: FC = () => {
+  const containerStyle: ContentStyleType = {
+    width: "100%",
+    height: "100%",
+  };
+
+  // とりあえず名古屋城を中心に表示
+  const center: CenterType = {
+    lat: 35.182253007459444,
+    lng: 136.90534328438358,
+  };
+
+  return (
+    <LoadScript googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAP_API_KEY || ""}>
+      <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={15}>
+        <MarkerF position={center} />
+      </GoogleMapComponent>
+    </LoadScript>
+  );
+};
+
+export default GoogleMap;

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from "react";
 import { GoogleMap as GoogleMapComponent, Marker, useJsApiLoader } from "@react-google-maps/api";
 
-type CenterType = {
-  lat: number;
-  lng: number;
+import { GoogleMapCenterType, ShopType } from "../../types";
+
+type Props = {
+  center: GoogleMapCenterType;
+  shops: ShopType[];
 };
 
 type ContentStyleType = {
@@ -16,21 +18,17 @@ const containerStyle: ContentStyleType = {
   height: "100%",
 };
 
-// 最終的にShopSearchコンポーネントのonSubmit関数の引数に渡された値を使って中心座標を決めたい
-const center: CenterType = {
-  lat: 35.182253007459444,
-  lng: 136.90534328438358,
-};
-
-const GoogleMap: FC = () => {
+const GoogleMap: FC<Props> = ({ center, shops }) => {
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || "",
   });
 
   return isLoaded ? (
-    <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={15}>
-      <Marker position={center} />
+    <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={11}>
+      {shops.map((shop) => (
+        <Marker key={shop.place_id} position={shop.geometry.location} />
+      ))}
     </GoogleMapComponent>
   ) : (
     <></>

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -16,7 +16,7 @@ const containerStyle: ContentStyleType = {
   height: "100%",
 };
 
-// とりあえず名古屋城を中心に表示
+// 最終的にShopSearchコンポーネントのonSubmit関数の引数に渡された値を使って中心座標を決めたい
 const center: CenterType = {
   lat: 35.182253007459444,
   lng: 136.90534328438358,

--- a/front/src/components/Header/AfterLoginMenu.tsx
+++ b/front/src/components/Header/AfterLoginMenu.tsx
@@ -41,9 +41,13 @@ const AfterLoginMenu: FC<Props> = ({ changeMenuState }) => {
         </div>
       </li>
       <li>
-        <a href="#" className="text-gray-800 hover:bg-reddishBrown hover:text-white">
+        <Link
+          to="shop-search"
+          className="text-gray-800 hover:bg-reddishBrown hover:text-white"
+          onClick={changeMenuState}
+        >
           ショップ検索
-        </a>
+        </Link>
       </li>
       <li>
         <Link

--- a/front/src/components/Header/BeforeLoginMenu.tsx
+++ b/front/src/components/Header/BeforeLoginMenu.tsx
@@ -9,9 +9,13 @@ const BeforeLoginMenu: FC<Props> = ({ changeMenuState }) => {
   return (
     <ul className="menu p-4 overflow-y-auto w-80 bg-base-100 text-base-content">
       <li>
-        <a href="#" className="text-gray-800 hover:bg-reddishBrown hover:text-white">
+        <Link
+          to="shop-search"
+          className="text-gray-800 hover:bg-reddishBrown hover:text-white"
+          onClick={changeMenuState}
+        >
           ショップ検索
-        </a>
+        </Link>
       </li>
       <li>
         <Link

--- a/front/src/components/ShopSearch/SearchForm.tsx
+++ b/front/src/components/ShopSearch/SearchForm.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FiX } from "react-icons/fi";
+import { inputSearchValidationSchema } from "../../utils/validationSchema";
+import { InputSearchParams } from "../../types";
+
+type SearchFormProps = {
+  onSubmit: (_data: InputSearchParams) => void; // eslint-disable-line no-unused-vars
+};
+
+const SearchForm: FC<SearchFormProps> = ({ onSubmit }) => {
+  const { register, handleSubmit, formState, reset } = useForm<InputSearchParams>({
+    mode: "onChange",
+    resolver: zodResolver(inputSearchValidationSchema),
+  });
+
+  const handleReset = () => {
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="flex">
+        <div className="relative">
+          <input
+            type="text"
+            placeholder="検索"
+            className="input input-bordered w-full max-w-xs"
+            {...register("search")}
+          />
+          {formState.isValid && (
+            <FiX
+              className="absolute right-2 top-1/2 transform -translate-y-1/2 cursor-pointer"
+              onClick={handleReset}
+            />
+          )}
+        </div>
+        <input
+          data-theme="valentine"
+          className="btn btn-neutral ml-3"
+          type="submit"
+          value="検索"
+          disabled={!formState.isValid}
+        />
+      </div>
+    </form>
+  );
+};
+
+export default SearchForm;

--- a/front/src/components/ShopSearch/ShopCard.tsx
+++ b/front/src/components/ShopSearch/ShopCard.tsx
@@ -1,0 +1,29 @@
+import React, { FC } from "react";
+import { ShopType } from "../../types";
+
+type ShopCardProps = {
+  shop: ShopType;
+};
+
+const ShopCard: FC<ShopCardProps> = ({ shop }) => {
+  const address = shop.formatted_address.replace(/日本、〒\d{3}-\d{4} /, "");
+  const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=600&photoreference=${shop.photos[0].photo_reference}&key=${process.env.REACT_APP_GOOGLE_MAP_API_KEY}`;
+
+  return (
+    <div key={shop.place_id} className="card w-88 bg-base-100 cursor-pointer">
+      <div className="card-body">
+        <div className="flex justify-between items-center">
+          <div className="flex-col ite">
+            <h2 className="card-title">{shop.name}</h2>
+            <p>{address}</p>
+          </div>
+          <div className="items-center">
+            <img src={photoUrl} alt="" className="w-20 h-20" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShopCard;

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from "react";
+
+const ShopSearch: FC = () => {
+  return (
+    <div className="flex h-screen">
+      <div className="w-1/3 bg-gray-200 overflow-auto">
+        {/* 左側のコンテンツをここに配置します */}
+        <p>左側のコンテンツ</p>
+      </div>
+      <div className="w-2/3 bg-gray-300">
+        {/* Googleマップを表示するためのコンテンツをここに配置します */}
+        <p>Googleマップの表示領域</p>
+      </div>
+    </div>
+  );
+};
+
+export default ShopSearch;

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -6,23 +6,32 @@ import { FiX } from "react-icons/fi";
 import axios from "axios";
 
 import GoogleMap from "../GoogleMap/GoogleMap";
-import { shopSearchValidationSchema } from "../../utils/validationSchema";
+import { inputSearchValidationSchema } from "../../utils/validationSchema";
 
-type ShopSearchParams = z.infer<typeof shopSearchValidationSchema>;
+type InputSearchParams = z.infer<typeof inputSearchValidationSchema>;
+
+type ShopType = {
+  place_id: string;
+  name: string;
+  formatted_address: string;
+};
 
 const ShopSearch: FC = () => {
-  const { register, handleSubmit, formState, reset } = useForm<ShopSearchParams>({
+  const { register, handleSubmit, formState, reset } = useForm<InputSearchParams>({
     mode: "onChange",
-    resolver: zodResolver(shopSearchValidationSchema),
+    resolver: zodResolver(inputSearchValidationSchema),
   });
 
-  const onSubmit = async (data: ShopSearchParams) => {
+  const [shops, setShops] = useState<ShopType[]>([]);
+
+  const onSubmit = async (data: InputSearchParams) => {
     try {
       const res = await axios.get(
         `${process.env.REACT_APP_BACKEND_API_URL}/shops/search?location=${data.search}`,
       );
       const results = res.data;
       console.log(results);
+      setShops(results.results);
     } catch (e) {
       console.log(e);
     }
@@ -63,12 +72,15 @@ const ShopSearch: FC = () => {
           </form>
           {/* Google Place APIから取得した店舗情報をここに表示する */}
           <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
-            <div className="card w-88 bg-base-100">
-              <div className="card-body ">
-                <h2 className="card-title">店舗名</h2>
-                <p>店舗の住所</p>
-              </div>
-            </div>
+            {shops.length > 0 &&
+              shops.map((shop: ShopType) => (
+                <div key={shop.place_id} className="card w-88 bg-base-100">
+                  <div className="card-body ">
+                    <h2 className="card-title">{shop.name}</h2>
+                    <p>{shop.formatted_address}</p>
+                  </div>
+                </div>
+              ))}
           </div>
         </div>
       </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -7,8 +7,9 @@ import axios from "axios";
 
 import GoogleMap from "../GoogleMap/GoogleMap";
 import { inputSearchValidationSchema } from "../../utils/validationSchema";
-import { GoogleMapCenterType, ShopType } from "../../types";
+import { GoogleMapCenterType } from "../../types";
 import { useShopContext } from "../../context/ShopContext";
+import ShopCard from "./ShopCard";
 
 type InputSearchParams = z.infer<typeof inputSearchValidationSchema>;
 
@@ -50,27 +51,6 @@ const ShopSearch: FC = () => {
     reset();
   };
 
-  // ショップの情報をカードにして表示する関数
-  const renderShopCard = (shop: ShopType) => {
-    const address = shop.formatted_address.replace(/日本、〒\d{3}-\d{4} /, "");
-    const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=600&photoreference=${shop.photos[0].photo_reference}&key=${process.env.REACT_APP_GOOGLE_MAP_API_KEY}`;
-    return (
-      <div key={shop.place_id} className="card w-88 bg-base-100 cursor-pointer">
-        <div className="card-body">
-          <div className="flex justify-between items-center">
-            <div className="flex-col ite">
-              <h2 className="card-title">{shop.name}</h2>
-              <p>{address}</p>
-            </div>
-            <div className="items-center">
-              <img src={photoUrl} alt="" className="w-20 h-20" />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  };
-
   return (
     <div className="flex h-screen">
       <div className="w-1/3 overflow-auto">
@@ -102,7 +82,7 @@ const ShopSearch: FC = () => {
           </form>
           {/* Google Place APIから取得した店舗情報をここに表示する */}
           <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
-            {shops.length > 0 && shops.map(renderShopCard)}
+            {shops.length > 0 && shops.map((shop) => <ShopCard key={shop.place_id} shop={shop} />)}
           </div>
         </div>
       </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { FiX } from "react-icons/fi";
+import axios from "axios";
 
 import GoogleMap from "../GoogleMap/GoogleMap";
 import { shopSearchValidationSchema } from "../../utils/validationSchema";
@@ -15,7 +16,17 @@ const ShopSearch: FC = () => {
     resolver: zodResolver(shopSearchValidationSchema),
   });
 
-  const onSubmit = (data: ShopSearchParams) => console.log(data);
+  const onSubmit = async (data: ShopSearchParams) => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_BACKEND_API_URL}/shops/search?location=${data.search}`,
+      );
+      const results = res.data;
+      console.log(results);
+    } catch (e) {
+      console.log(e);
+    }
+  };
 
   const handleReset = () => {
     reset();
@@ -52,18 +63,6 @@ const ShopSearch: FC = () => {
           </form>
           {/* Google Place APIから取得した店舗情報をここに表示する */}
           <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
-            <div className="card w-88 bg-base-100">
-              <div className="card-body ">
-                <h2 className="card-title">店舗名</h2>
-                <p>店舗の住所</p>
-              </div>
-            </div>
-            <div className="card w-88 bg-base-100">
-              <div className="card-body ">
-                <h2 className="card-title">店舗名</h2>
-                <p>店舗の住所</p>
-              </div>
-            </div>
             <div className="card w-88 bg-base-100">
               <div className="card-body ">
                 <h2 className="card-title">店舗名</h2>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -14,6 +14,9 @@ type ShopType = {
   place_id: string;
   name: string;
   formatted_address: string;
+  photos: {
+    photo_reference: string;
+  }[];
 };
 
 const ShopSearch: FC = () => {
@@ -44,11 +47,19 @@ const ShopSearch: FC = () => {
   // ショップの情報をカードにして表示
   const renderShopCard = (shop: ShopType) => {
     const address = shop.formatted_address.replace(/日本、〒\d{3}-\d{4} /, "");
+    const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=600&photoreference=${shop.photos[0].photo_reference}&key=${process.env.REACT_APP_GOOGLE_MAP_API_KEY}`;
     return (
-      <div key={shop.place_id} className="card w-88 bg-base-100">
-        <div className="card-body ">
-          <h2 className="card-title">{shop.name}</h2>
-          <p>{address}</p>
+      <div key={shop.place_id} className="card w-88 bg-base-100 cursor-pointer">
+        <div className="card-body">
+          <div className="flex justify-between items-center">
+            <div className="flex-col ite">
+              <h2 className="card-title">{shop.name}</h2>
+              <p>{address}</p>
+            </div>
+            <div className="items-center">
+              <img src={photoUrl} alt="" className="w-20 h-20" />
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -1,16 +1,79 @@
 import React, { FC } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { FiX } from "react-icons/fi";
+
 import GoogleMap from "../GoogleMap/GoogleMap";
+import { shopSearchValidationSchema } from "../../utils/validationSchema";
+
+type ShopSearchParams = z.infer<typeof shopSearchValidationSchema>;
 
 const ShopSearch: FC = () => {
+  const { register, handleSubmit, formState, reset } = useForm<ShopSearchParams>({
+    mode: "onChange",
+    resolver: zodResolver(shopSearchValidationSchema),
+  });
+
+  const onSubmit = (data: ShopSearchParams) => console.log(data);
+
+  const handleReset = () => {
+    reset();
+  };
+
   return (
     <div className="flex h-screen">
-      <div className="w-1/3 bg-gray-200 overflow-auto">
-        {/* 左側のコンテンツをここに配置します */}
-        <p>左側のコンテンツ</p>
+      <div className="w-1/3 overflow-auto">
+        <div className="p-4 flex flex-col h-full">
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <div className="flex">
+              <div className="relative">
+                <input
+                  type="text"
+                  placeholder="検索"
+                  className="input input-bordered w-full max-w-xs"
+                  {...register("search")}
+                />
+                {formState.isValid && (
+                  <FiX
+                    className="absolute right-2 top-1/2 transform -translate-y-1/2 cursor-pointer"
+                    onClick={handleReset}
+                  />
+                )}
+              </div>
+              <input
+                data-theme="valentine"
+                className="btn btn-neutral ml-3"
+                type="submit"
+                value="検索"
+                disabled={!formState.isValid}
+              />
+            </div>
+          </form>
+          {/* Google Place APIから取得した店舗情報をここに表示する */}
+          <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
+            <div className="card w-88 bg-base-100">
+              <div className="card-body ">
+                <h2 className="card-title">店舗名</h2>
+                <p>店舗の住所</p>
+              </div>
+            </div>
+            <div className="card w-88 bg-base-100">
+              <div className="card-body ">
+                <h2 className="card-title">店舗名</h2>
+                <p>店舗の住所</p>
+              </div>
+            </div>
+            <div className="card w-88 bg-base-100">
+              <div className="card-body ">
+                <h2 className="card-title">店舗名</h2>
+                <p>店舗の住所</p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <div className="w-2/3">
-        <GoogleMap />
-      </div>
+      <div className="w-2/3">{<GoogleMap />}</div>
     </div>
   );
 };

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -41,6 +41,19 @@ const ShopSearch: FC = () => {
     reset();
   };
 
+  // ショップの情報をカードにして表示
+  const renderShopCard = (shop: ShopType) => {
+    const address = shop.formatted_address.replace(/日本、〒\d{3}-\d{4} /, "");
+    return (
+      <div key={shop.place_id} className="card w-88 bg-base-100">
+        <div className="card-body ">
+          <h2 className="card-title">{shop.name}</h2>
+          <p>{address}</p>
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="flex h-screen">
       <div className="w-1/3 overflow-auto">
@@ -72,15 +85,7 @@ const ShopSearch: FC = () => {
           </form>
           {/* Google Place APIから取得した店舗情報をここに表示する */}
           <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
-            {shops.length > 0 &&
-              shops.map((shop: ShopType) => (
-                <div key={shop.place_id} className="card w-88 bg-base-100">
-                  <div className="card-body ">
-                    <h2 className="card-title">{shop.name}</h2>
-                    <p>{shop.formatted_address}</p>
-                  </div>
-                </div>
-              ))}
+            {shops.length > 0 && shops.map(renderShopCard)}
           </div>
         </div>
       </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -1,24 +1,13 @@
 import React, { FC, useState } from "react";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { FiX } from "react-icons/fi";
 import axios from "axios";
 
 import GoogleMap from "../GoogleMap/GoogleMap";
-import { inputSearchValidationSchema } from "../../utils/validationSchema";
-import { GoogleMapCenterType } from "../../types";
+import { GoogleMapCenterType, InputSearchParams } from "../../types";
 import { useShopContext } from "../../context/ShopContext";
 import ShopCard from "./ShopCard";
-
-type InputSearchParams = z.infer<typeof inputSearchValidationSchema>;
+import SearchForm from "./SearchForm";
 
 const ShopSearch: FC = () => {
-  const { register, handleSubmit, formState, reset } = useForm<InputSearchParams>({
-    mode: "onChange",
-    resolver: zodResolver(inputSearchValidationSchema),
-  });
-
   // 名古屋をデフォルトの中心に設定
   const defaultCenter: GoogleMapCenterType = {
     lat: 35.182253007459444,
@@ -47,39 +36,11 @@ const ShopSearch: FC = () => {
     }
   };
 
-  const handleReset = () => {
-    reset();
-  };
-
   return (
     <div className="flex h-screen">
       <div className="w-1/3 overflow-auto">
         <div className="p-4 flex flex-col h-full">
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <div className="flex">
-              <div className="relative">
-                <input
-                  type="text"
-                  placeholder="検索"
-                  className="input input-bordered w-full max-w-xs"
-                  {...register("search")}
-                />
-                {formState.isValid && (
-                  <FiX
-                    className="absolute right-2 top-1/2 transform -translate-y-1/2 cursor-pointer"
-                    onClick={handleReset}
-                  />
-                )}
-              </div>
-              <input
-                data-theme="valentine"
-                className="btn btn-neutral ml-3"
-                type="submit"
-                value="検索"
-                disabled={!formState.isValid}
-              />
-            </div>
-          </form>
+          <SearchForm onSubmit={onSubmit} />
           {/* Google Place APIから取得した店舗情報をここに表示する */}
           <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
             {shops.length > 0 && shops.map((shop) => <ShopCard key={shop.place_id} shop={shop} />)}

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -8,6 +8,7 @@ import axios from "axios";
 import GoogleMap from "../GoogleMap/GoogleMap";
 import { inputSearchValidationSchema } from "../../utils/validationSchema";
 import { GoogleMapCenterType, ShopType } from "../../types";
+import { useShopContext } from "../../context/ShopContext";
 
 type InputSearchParams = z.infer<typeof inputSearchValidationSchema>;
 
@@ -23,7 +24,7 @@ const ShopSearch: FC = () => {
     lng: 136.90534328438358,
   };
 
-  const [shops, setShops] = useState<ShopType[]>([]);
+  const { shops, setShops } = useShopContext();
   const [center, setCenter] = useState<GoogleMapCenterType>(defaultCenter);
 
   const onSubmit = async (data: InputSearchParams) => {
@@ -49,7 +50,7 @@ const ShopSearch: FC = () => {
     reset();
   };
 
-  // ショップの情報をカードにして表示
+  // ショップの情報をカードにして表示する関数
   const renderShopCard = (shop: ShopType) => {
     const address = shop.formatted_address.replace(/日本、〒\d{3}-\d{4} /, "");
     const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=600&photoreference=${shop.photos[0].photo_reference}&key=${process.env.REACT_APP_GOOGLE_MAP_API_KEY}`;
@@ -105,7 +106,7 @@ const ShopSearch: FC = () => {
           </div>
         </div>
       </div>
-      <div className="w-2/3">{<GoogleMap center={center} shops={shops} />}</div>
+      <div className="w-2/3">{<GoogleMap center={center} />}</div>
     </div>
   );
 };

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -7,17 +7,9 @@ import axios from "axios";
 
 import GoogleMap from "../GoogleMap/GoogleMap";
 import { inputSearchValidationSchema } from "../../utils/validationSchema";
+import { GoogleMapCenterType, ShopType } from "../../types";
 
 type InputSearchParams = z.infer<typeof inputSearchValidationSchema>;
-
-type ShopType = {
-  place_id: string;
-  name: string;
-  formatted_address: string;
-  photos: {
-    photo_reference: string;
-  }[];
-};
 
 const ShopSearch: FC = () => {
   const { register, handleSubmit, formState, reset } = useForm<InputSearchParams>({
@@ -25,7 +17,14 @@ const ShopSearch: FC = () => {
     resolver: zodResolver(inputSearchValidationSchema),
   });
 
+  // 名古屋をデフォルトの中心に設定
+  const defaultCenter: GoogleMapCenterType = {
+    lat: 35.182253007459444,
+    lng: 136.90534328438358,
+  };
+
   const [shops, setShops] = useState<ShopType[]>([]);
+  const [center, setCenter] = useState<GoogleMapCenterType>(defaultCenter);
 
   const onSubmit = async (data: InputSearchParams) => {
     try {
@@ -34,6 +33,12 @@ const ShopSearch: FC = () => {
       );
       const results = res.data;
       console.log(results);
+      if (results.results.length > 0)
+        setCenter({
+          lat: results.results[0].geometry.location.lat,
+          lng: results.results[0].geometry.location.lng,
+        });
+
       setShops(results.results);
     } catch (e) {
       console.log(e);
@@ -100,7 +105,7 @@ const ShopSearch: FC = () => {
           </div>
         </div>
       </div>
-      <div className="w-2/3">{<GoogleMap />}</div>
+      <div className="w-2/3">{<GoogleMap center={center} shops={shops} />}</div>
     </div>
   );
 };

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from "react";
+import GoogleMap from "../GoogleMap/GoogleMap";
 
 const ShopSearch: FC = () => {
   return (
@@ -7,9 +8,8 @@ const ShopSearch: FC = () => {
         {/* 左側のコンテンツをここに配置します */}
         <p>左側のコンテンツ</p>
       </div>
-      <div className="w-2/3 bg-gray-300">
-        {/* Googleマップを表示するためのコンテンツをここに配置します */}
-        <p>Googleマップの表示領域</p>
+      <div className="w-2/3">
+        <GoogleMap />
       </div>
     </div>
   );

--- a/front/src/context/ShopContext.tsx
+++ b/front/src/context/ShopContext.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState } from "react";
+import { ShopType } from "../types";
+
+type ShopContextType = {
+  shops: ShopType[];
+  setShops: React.Dispatch<React.SetStateAction<ShopType[]>>;
+};
+
+type ShopProviderProps = {
+  children: React.ReactNode;
+};
+
+const ShopContext = createContext<ShopContextType>({} as ShopContextType);
+
+export const ShopProvider = ({ children }: ShopProviderProps) => {
+  const [shops, setShops] = useState<ShopType[]>([]);
+
+  const ShopContextValue = {
+    shops,
+    setShops,
+  };
+
+  return <ShopContext.Provider value={ShopContextValue}>{children}</ShopContext.Provider>;
+};
+
+export const useShopContext = () => useContext(ShopContext);

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -1,9 +1,15 @@
 import { z } from "zod";
-import { loginValidationSchema, registerValidationSchema } from "../utils/validationSchema";
+import {
+  inputSearchValidationSchema,
+  loginValidationSchema,
+  registerValidationSchema,
+} from "../utils/validationSchema";
 
 export type SignUpParams = z.infer<typeof registerValidationSchema>;
 
 export type LoginParams = z.infer<typeof loginValidationSchema>;
+
+export type InputSearchParams = z.infer<typeof inputSearchValidationSchema>;
 
 export type User = {
   id: number;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -16,3 +16,23 @@ export type User = {
   created_at: Date;
   updated_at: Date;
 };
+
+export type ShopType = {
+  place_id: string;
+  name: string;
+  formatted_address: string;
+  photos: {
+    photo_reference: string;
+  }[];
+  geometry: {
+    location: {
+      lat: number;
+      lng: number;
+    };
+  };
+};
+
+export type GoogleMapCenterType = {
+  lat: number;
+  lng: number;
+};

--- a/front/src/utils/validationSchema.ts
+++ b/front/src/utils/validationSchema.ts
@@ -35,6 +35,6 @@ export const registerValidationSchema = z
     path: ["passwordConfirmation"],
   });
 
-export const shopSearchValidationSchema = z.object({
+export const inputSearchValidationSchema = z.object({
   search: z.string().nonempty("検索ワードを入力してください"),
 });

--- a/front/src/utils/validationSchema.ts
+++ b/front/src/utils/validationSchema.ts
@@ -34,3 +34,7 @@ export const registerValidationSchema = z
     message: "パスワードと確認用パスワードが一致していません",
     path: ["passwordConfirmation"],
   });
+
+export const shopSearchValidationSchema = z.object({
+  search: z.string().nonempty("検索ワードを入力してください"),
+});


### PR DESCRIPTION
### 概要
ShopSearchコンポーネントを作成し、画面の2/3はGoogleマップを表示・1/3はAPIから取得したショップ情報をカードで表示されるようにした。APIから取得したショップ情報はグローバルstateで管理してある。
検索ボックスは入力されていない場合はボタンが非活性になるようにしてあるが、最大入力数にバリデーションを設定していないので気になるようだったら後で設定しておこうと思う。

### 該当Issues
#9 
#14 