### PR TITLE
ショップのブックマーク機能を追加

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -34,3 +34,6 @@
 # Ignore dotenv config.
 /.env
 /.env.development
+
+# uploader
+/public/uploads/

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -42,6 +42,7 @@ gem 'devise_token_auth'
 
 # 画像アップロード
 gem 'carrierwave'
+gem 'mini_magick'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -40,6 +40,9 @@ gem "rack-cors"
 gem 'devise'
 gem 'devise_token_auth'
 
+# 画像アップロード
+gem 'carrierwave'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -240,6 +240,7 @@ DEPENDENCIES
   devise
   devise_token_auth
   dotenv-rails
+  mini_magick
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rack-cors

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     bcrypt (3.1.19)
     bootsnap (1.16.0)
@@ -74,6 +76,13 @@ GEM
     bullet (7.0.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    carrierwave (3.0.0)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -95,10 +104,14 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.12.0)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.6.0)
     irb (1.7.0)
       reline (>= 0.3.0)
@@ -113,6 +126,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.1)
@@ -134,6 +148,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -198,6 +213,9 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
+    ssrf_filter (1.1.1)
     thor (1.2.2)
     timeout (0.3.2)
     tzinfo (2.0.6)
@@ -217,6 +235,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   bullet
+  carrierwave
   debug
   devise
   devise_token_auth

--- a/api/app/controllers/api/v1/bookmarks_controller.rb
+++ b/api/app/controllers/api/v1/bookmarks_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BookmarksController < ApplicationController
-  before_action :set_shop
+  before_action :set_shop, only: [:create, :destroy]
 
   def index
     bookmarks = current_api_v1_user.bookmarked_shops

--- a/api/app/controllers/api/v1/bookmarks_controller.rb
+++ b/api/app/controllers/api/v1/bookmarks_controller.rb
@@ -1,0 +1,28 @@
+class Api::V1::BookmarksController < ApplicationController
+  before_action :set_shop
+
+  def index
+    bookmarks = current_api_v1_user.bookmarked_shops
+    render json: bookmarks
+  end
+
+  def create
+    current_api_v1_user.bookmark(@shop)
+    render json: { status: :created }
+  end
+
+  def destroy
+    current_api_v1_user.remove_bookmark(@shop)
+    render json: { status: :ok }
+  end
+
+  private
+
+  def set_shop
+    @shop = Shop.find_or_create_by_place(bookmark_params)
+  end
+
+  def bookmark_params
+    params.require(:shop).permit(:place_id, :name, :formatted_address, :photos, :website)
+  end
+end

--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::ShopsController < ApplicationController
 
   def show
     plase_id = params[:id]
-    fields = "formatted_address,name,geometry,photos,current_opening_hours,website"
+    fields = "formatted_address,name,geometry,photos,current_opening_hours,website,place_id"
     uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/details/json?place_id=#{plase_id}&fields=#{fields}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
     res = Net::HTTP.get_response(uri)
     render json: res.body

--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::ShopsController < ApplicationController
   require "cgi"
 
   def search
-    query = CGI.escape("芋のお菓子専門店+in+#{params[:location]}")
+    query = CGI.escape("さつまいも菓子専門店+in+#{params[:location]}")
     fields = "formatted_address,name,geometry,place_id,photos"
     uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/textsearch/json?query=#{query}&fields=#{fields}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
     res = Net::HTTP.get_response(uri)

--- a/api/app/models/bookmark.rb
+++ b/api/app/models/bookmark.rb
@@ -1,0 +1,3 @@
+class Bookmark < ApplicationRecord
+  validates :user_id, uniqueness: { scope: :shop_id }
+end

--- a/api/app/models/bookmark.rb
+++ b/api/app/models/bookmark.rb
@@ -1,3 +1,6 @@
 class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :shop
+
   validates :user_id, uniqueness: { scope: :shop_id }
 end

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -1,4 +1,7 @@
 class Shop < ApplicationRecord
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmarked_by_users, through: :bookmarks, source: :user
+
   validates :name, :formatted_address, :place_id, presence: true
   validates :place_id, uniqueness: true
 end

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -1,0 +1,4 @@
+class Shop < ApplicationRecord
+  validates :name, :formatted_address, :place_id, presence: true
+  validates :place_id, uniqueness: true
+end

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -1,4 +1,6 @@
 class Shop < ApplicationRecord
+  mount_uploader :photos, PhotoUploader
+
   has_many :bookmarks, dependent: :destroy
   has_many :bookmarked_by_users, through: :bookmarks, source: :user
 

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -12,7 +12,7 @@ class Shop < ApplicationRecord
     find_or_create_by(place_id: params[:place_id]) do |shop|
       shop.name = params[:name]
       shop.formatted_address = params[:formatted_address]
-      shop.photos = params[:photos]
+      shop.remote_photos_url = params[:photos]
       shop.website = params[:website]
     end
   end

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -4,4 +4,14 @@ class Shop < ApplicationRecord
 
   validates :name, :formatted_address, :place_id, presence: true
   validates :place_id, uniqueness: true
+
+  # 与えられたplace_idで店舗を検索し、存在しなければ新たに作成。
+  def self.find_or_create_by_place(params)
+    find_or_create_by(place_id: params[:place_id]) do |shop|
+      shop.name = params[:name]
+      shop.formatted_address = params[:formatted_address]
+      shop.photos = params[:photos]
+      shop.website = params[:website]
+    end
+  end
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -8,4 +8,12 @@ class User < ActiveRecord::Base
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, uniqueness: { case_sensitive: true }
+
+  def bookmark(shop)
+    bookmarked_shops << shop
+  end
+
+  def remove_bookmark(shop)
+    bookmarked_shops.destroy(shop)
+  end
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,11 +1,10 @@
-# frozen_string_literal: true
-
 class User < ActiveRecord::Base
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmarked_shops, through: :bookmarks, source: :shop
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, uniqueness: { case_sensitive: true }

--- a/api/app/uploaders/photo_uploader.rb
+++ b/api/app/uploaders/photo_uploader.rb
@@ -1,0 +1,47 @@
+class PhotoUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/api/app/uploaders/photo_uploader.rb
+++ b/api/app/uploaders/photo_uploader.rb
@@ -1,7 +1,9 @@
 class PhotoUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
+
+  process resize_to_fit: [800, 800]
 
   # Choose what kind of storage to use for this uploader:
   storage :file

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
           get :search
         end
       end
+
+      resources :bookmarks, only: %i[index create destroy]
     end
   end
 end

--- a/api/db/migrate/20230718021842_create_shops.rb
+++ b/api/db/migrate/20230718021842_create_shops.rb
@@ -1,0 +1,14 @@
+class CreateShops < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shops do |t|
+      t.string :name, null: false
+      t.string :formatted_address, null: false
+      t.string :photos
+      t.string :place_id, null: false
+      t.string :website
+
+      t.timestamps
+    end
+    add_index :shops, :place_id, unique: true
+  end
+end

--- a/api/db/migrate/20230718080716_create_bookmarks.rb
+++ b/api/db/migrate/20230718080716_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :shop, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :bookmarks, [:user_id, :shop_id], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_05_072731) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_021842) do
+  create_table "shops", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "formatted_address", null: false
+    t.string "photos"
+    t.string "place_id", null: false
+    t.string "website"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["place_id"], name: "index_shops_on_place_id", unique: true
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_021842) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_080716) do
+  create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "shop_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shop_id"], name: "index_bookmarks_on_shop_id"
+    t.index ["user_id", "shop_id"], name: "index_bookmarks_on_user_id_and_shop_id", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
   create_table "shops", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "formatted_address", null: false
@@ -46,4 +56,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_021842) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "bookmarks", "shops"
+  add_foreign_key "bookmarks", "users"
 end

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -3,16 +3,16 @@ import { Link, useParams } from "react-router-dom";
 import { MdOutlineArrowBackIos } from "react-icons/md";
 import axios from "axios";
 import { useJsApiLoader } from "@react-google-maps/api";
-import { FaStar, FaRegStar } from "react-icons/fa";
 
 import { GoogleMapCenterType, ShopType } from "../../types";
-import { formatAddress, getPhotoUrl, getAuthHeaders } from "../../utils/utils";
+import { getPhotoUrl, getAuthHeaders } from "../../utils/utils";
 import GoogleMap from "../GoogleMap/GoogleMap";
 import { useAuthContext } from "../../context/AuthContext";
+import ShopInfoCard from "./ShopInfoCard";
+import { useShopDetail } from "../../hooks/useShopDetail";
 
 const ShopDetail: FC = () => {
   const { id } = useParams();
-  const [shopDetail, setShopDetail] = useState<ShopType>();
   const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
   const { isSignedIn } = useAuthContext();
 
@@ -23,32 +23,8 @@ const ShopDetail: FC = () => {
 
   const headers = getAuthHeaders();
 
-  const renderWeekdays = (weekday_text: string[]) => {
-    return weekday_text.map((day) => {
-      const [dayOfWeek, time] = day.split(": ");
-      return (
-        <div key={day} className="flex w-full">
-          <div className="ml-16">
-            {dayOfWeek}:　{time}
-          </div>
-        </div>
-      );
-    });
-  };
-
   // ショップの詳細情報を取得
-  useEffect(() => {
-    const getShopDetail = async () => {
-      try {
-        const res = await axios.get(`${process.env.REACT_APP_BACKEND_API_URL}/shops/${id}`);
-        setShopDetail(res.data.result);
-      } catch (err) {
-        console.error(err);
-      }
-    };
-
-    getShopDetail();
-  }, []);
+  const shopDetail = useShopDetail(id);
 
   // ブックマークされているかどうかをチェック
   useEffect(() => {
@@ -78,23 +54,23 @@ const ShopDetail: FC = () => {
       </div>
     );
 
-  const address = formatAddress(shopDetail.formatted_address);
-
-  const photoUrl = getPhotoUrl(shopDetail.photos[0].photo_reference, 400);
+  const { place_id, name, formatted_address, website, photos, geometry } = shopDetail;
+  const photoUrl = getPhotoUrl(photos[0].photo_reference, 400);
 
   const center: GoogleMapCenterType = {
-    lat: shopDetail.geometry.location.lat,
-    lng: shopDetail.geometry.location.lng,
+    lat: geometry.location.lat,
+    lng: geometry.location.lng,
   };
 
+  // ブックマークの追加・削除
   const handleBookmark = async () => {
     const shopData = {
       shop: {
-        place_id: shopDetail.place_id,
-        name: shopDetail.name,
-        formatted_address: shopDetail.formatted_address,
+        place_id: place_id,
+        name: name,
+        formatted_address: formatted_address,
         photos: photoUrl,
-        website: shopDetail.website,
+        website: website,
       },
     };
     if (isBookmarked)
@@ -129,61 +105,14 @@ const ShopDetail: FC = () => {
                 <button className="mr-2">戻る</button>
               </div>
             </Link>
-            <div className="text-2xl font-bold">{shopDetail.name}</div>
+            <div className="text-2xl font-bold">{name}</div>
           </div>
-          {/* ここに店舗情報を表示する */}
-          <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
-            <div className="card bg-base-100">
-              <div className="card-body">
-                <div className="flex flex-col">
-                  <img
-                    src={photoUrl}
-                    alt=""
-                    className="artboard artboard-horizontal phone-1 mb-4 rounded-lg"
-                  />
-                  {isSignedIn && (
-                    <div className="flex items-center justify-center mb-7 w-full">
-                      <div className="font-bold text-2xl text-reddishBrown">お気に入り　　</div>
-                      <div>
-                        {isBookmarked ? (
-                          <FaStar className="text-yellow-300 text-3xl" onClick={handleBookmark} />
-                        ) : (
-                          <FaRegStar
-                            className="text-yellow-300 text-3xl"
-                            onClick={handleBookmark}
-                          />
-                        )}
-                      </div>
-                    </div>
-                  )}
-                  <div className="flex flex-col items-center mb-7 w-full">
-                    <div className="font-bold text-lg mb-2 text-reddishBrown">営業日時</div>
-                    {shopDetail.current_opening_hours &&
-                      renderWeekdays(shopDetail.current_opening_hours.weekday_text)}
-                  </div>
-                  <div className="flex flex-col items-center mb-7 w-full">
-                    <div className="font-bold text-lg mb-2 text-reddishBrown">住所</div>
-                    <div>{address}</div>
-                  </div>
-                  <div className="flex flex-col items-center w-full mb-7">
-                    <div className="font-bold text-lg text-reddishBrown">公式HP</div>
-                    {shopDetail.website ? (
-                      <a
-                        href={shopDetail.website}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="link link-hover"
-                      >
-                        ホームページを閲覧する
-                      </a>
-                    ) : (
-                      <div>ホームページが見つかりませんでした</div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          {/* ここに店舗情報を表示 */}
+          <ShopInfoCard
+            shopDetail={shopDetail}
+            isBookmarked={isBookmarked}
+            handleBookmark={handleBookmark}
+          />
         </div>
       </div>
       <div className="w-2/3 bg-white">{<GoogleMap center={center} zoom={15} />}</div>

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -3,14 +3,18 @@ import { Link, useParams } from "react-router-dom";
 import { MdOutlineArrowBackIos } from "react-icons/md";
 import axios from "axios";
 import { useJsApiLoader } from "@react-google-maps/api";
+import { FaStar, FaRegStar } from "react-icons/fa";
 
 import { GoogleMapCenterType, ShopType } from "../../types";
 import { formatAddress, getPhotoUrl } from "../../utils/utils";
 import GoogleMap from "../GoogleMap/GoogleMap";
+import { useAuthContext } from "../../context/AuthContext";
 
 const ShopDetail: FC = () => {
   const { id } = useParams();
   const [shopDetail, setShopDetail] = useState<ShopType>();
+  const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
+  const { isSignedIn } = useAuthContext();
 
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
@@ -83,17 +87,29 @@ const ShopDetail: FC = () => {
                     alt=""
                     className="artboard artboard-horizontal phone-1 mb-4 rounded-lg"
                   />
-                  <div className="flex flex-col items-center mb-4 w-full">
-                    <div className="font-bold text-lg mb-2">営業日時</div>
+                  {isSignedIn && (
+                    <div className="flex items-center justify-center mb-7 w-full">
+                      <div className="font-bold text-2xl text-reddishBrown">お気に入り　　</div>
+                      <div>
+                        {isBookmarked ? (
+                          <FaStar className="text-yellow-300 text-3xl" />
+                        ) : (
+                          <FaRegStar className="text-yellow-300 text-3xl" />
+                        )}
+                      </div>
+                    </div>
+                  )}
+                  <div className="flex flex-col items-center mb-7 w-full">
+                    <div className="font-bold text-lg mb-2 text-reddishBrown">営業日時</div>
                     {shopDetail.current_opening_hours &&
                       renderWeekdays(shopDetail.current_opening_hours.weekday_text)}
                   </div>
-                  <div className="flex flex-col items-center mb-4 w-full">
-                    <div className="font-bold text-lg mb-2">住所</div>
+                  <div className="flex flex-col items-center mb-7 w-full">
+                    <div className="font-bold text-lg mb-2 text-reddishBrown">住所</div>
                     <div>{address}</div>
                   </div>
-                  <div className="flex flex-col items-center w-full mb-4">
-                    <div className="font-bold text-lg">ホームページ</div>
+                  <div className="flex flex-col items-center w-full mb-7">
+                    <div className="font-bold text-lg text-reddishBrown">ホームページ</div>
                     {shopDetail.website ? (
                       <a
                         href={shopDetail.website}

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -94,10 +94,17 @@ const ShopDetail: FC = () => {
                   </div>
                   <div className="flex flex-col items-center w-full mb-4">
                     <div className="font-bold text-lg">ホームページ</div>
-                    {shopDetail.website && (
-                      <a href={shopDetail.website} className="link link-hover">
+                    {shopDetail.website ? (
+                      <a
+                        href={shopDetail.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="link link-hover"
+                      >
                         ホームページを閲覧する
                       </a>
+                    ) : (
+                      <div>ホームページが見つかりませんでした</div>
                     )}
                   </div>
                 </div>

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -93,7 +93,7 @@ const ShopDetail: FC = () => {
         place_id: shopDetail.place_id,
         name: shopDetail.name,
         formatted_address: shopDetail.formatted_address,
-        photos: shopDetail.photos[0].photo_reference,
+        photos: photoUrl,
         website: shopDetail.website,
       },
     };
@@ -166,7 +166,7 @@ const ShopDetail: FC = () => {
                     <div>{address}</div>
                   </div>
                   <div className="flex flex-col items-center w-full mb-7">
-                    <div className="font-bold text-lg text-reddishBrown">ホームページ</div>
+                    <div className="font-bold text-lg text-reddishBrown">公式HP</div>
                     {shopDetail.website ? (
                       <a
                         href={shopDetail.website}

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -1,0 +1,84 @@
+import React, { FC } from "react";
+import { FaStar, FaRegStar } from "react-icons/fa";
+import { ShopType } from "../../types";
+import { formatAddress, getPhotoUrl } from "../../utils/utils";
+import { useAuthContext } from "../../context/AuthContext";
+
+type ShopInfoCardProps = {
+  shopDetail: ShopType;
+  isBookmarked: boolean;
+  handleBookmark: () => void;
+};
+
+const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleBookmark }) => {
+  const { formatted_address, website, photos, current_opening_hours } = shopDetail;
+  const { isSignedIn } = useAuthContext();
+  const address = formatAddress(formatted_address);
+  const photoUrl = getPhotoUrl(photos[0].photo_reference, 400);
+
+  const renderWeekdays = (weekday_text: string[]) => {
+    return weekday_text.map((day) => {
+      const [dayOfWeek, time] = day.split(": ");
+      return (
+        <div key={day} className="flex w-full">
+          <div className="ml-16">
+            {dayOfWeek}:　{time}
+          </div>
+        </div>
+      );
+    });
+  };
+
+  return (
+    <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
+      <div className="card bg-base-100">
+        <div className="card-body">
+          <div className="flex flex-col">
+            <img
+              src={photoUrl}
+              alt=""
+              className="artboard artboard-horizontal phone-1 mb-4 rounded-lg"
+            />
+            {isSignedIn && (
+              <div className="flex items-center justify-center mb-7 w-full">
+                <div className="font-bold text-2xl text-reddishBrown">お気に入り　　</div>
+                <div>
+                  {isBookmarked ? (
+                    <FaStar className="text-yellow-300 text-3xl" onClick={handleBookmark} />
+                  ) : (
+                    <FaRegStar className="text-yellow-300 text-3xl" onClick={handleBookmark} />
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="flex flex-col items-center mb-7 w-full">
+              <div className="font-bold text-lg mb-2 text-reddishBrown">営業日時</div>
+              {current_opening_hours && renderWeekdays(current_opening_hours.weekday_text)}
+            </div>
+            <div className="flex flex-col items-center mb-7 w-full">
+              <div className="font-bold text-lg mb-2 text-reddishBrown">住所</div>
+              <div>{address}</div>
+            </div>
+            <div className="flex flex-col items-center mb-7 w-full">
+              <div className="font-bold text-lg text-reddishBrown">公式HP</div>
+              {website ? (
+                <a
+                  href={website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="link link-hover"
+                >
+                  ホームページを閲覧する
+                </a>
+              ) : (
+                <div>ホームページが見つかりませんでした</div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShopInfoCard;

--- a/front/src/components/ShopSearch/SearchForm.tsx
+++ b/front/src/components/ShopSearch/SearchForm.tsx
@@ -21,7 +21,7 @@ const SearchForm: FC<SearchFormProps> = ({ onSubmit }) => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <div className="flex">
+      <div className="flex justify-center items-center">
         <div className="relative">
           <input
             type="text"

--- a/front/src/components/ShopSearch/ShopCard.tsx
+++ b/front/src/components/ShopSearch/ShopCard.tsx
@@ -1,21 +1,27 @@
 import React, { FC } from "react";
-import { ShopType } from "../../types";
+import { RailsShopType, ShopType } from "../../types";
 import { useNavigate } from "react-router-dom";
 import { formatAddress, getPhotoUrl } from "../../utils/utils";
 
 type ShopCardProps = {
-  shop: ShopType;
+  shop: ShopType | RailsShopType;
 };
 
 const ShopCard: FC<ShopCardProps> = ({ shop }) => {
   // お店が営業していない場合は表示しない
-  if (shop.business_status !== "OPERATIONAL") return null;
+  if (shop.business_status && shop.business_status !== "OPERATIONAL") return null;
 
   const navigate = useNavigate();
 
   const address = formatAddress(shop.formatted_address);
 
-  const photoUrl = getPhotoUrl(shop.photos[0].photo_reference, 600);
+  // 画像URLを取得する
+  let photoUrl;
+  if ("url" in shop.photos)
+    // RailsAPIからのデータの場合
+    photoUrl = `${process.env.REACT_APP_BACKEND_HOST_URL}${shop.photos.url}`;
+  // Google Place APIからのデータの場合
+  else photoUrl = getPhotoUrl(shop.photos[0].photo_reference, 600);
 
   return (
     <div

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -61,7 +61,6 @@ const ShopSearch: FC = () => {
         headers,
       });
       setBookmarks(res.data);
-      console.log(res.data);
     } catch (e) {
       console.log(e);
     }
@@ -79,10 +78,16 @@ const ShopSearch: FC = () => {
           <SearchForm onSubmit={onSubmit} />
           {isSignedIn && (
             <div className="tabs justify-center items-center my-3">
-              <div className="tab tab-lg tab-bordered tab-active" onClick={() => setTab("all")}>
+              <div
+                className={`tab tab-lg tab-bordered ${tab === "all" ? "tab-active" : ""}`}
+                onClick={() => setTab("all")}
+              >
                 すべて
               </div>
-              <div className="tab tab-lg tab-bordered" onClick={() => setTab("bookmarks")}>
+              <div
+                className={`tab tab-lg tab-bordered ${tab === "bookmarks" ? "tab-active" : ""}`}
+                onClick={() => setTab("bookmarks")}
+              >
                 お気に入り
               </div>
             </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -6,6 +6,7 @@ import { GoogleMapCenterType, InputSearchParams } from "../../types";
 import { useShopContext } from "../../context/ShopContext";
 import ShopCard from "./ShopCard";
 import SearchForm from "./SearchForm";
+import { useAuthContext } from "../../context/AuthContext";
 
 const ShopSearch: FC = () => {
   // 名古屋をデフォルトの中心に設定
@@ -14,6 +15,7 @@ const ShopSearch: FC = () => {
     lng: 136.90534328438358,
   };
 
+  const { isSignedIn } = useAuthContext();
   const { shops, setShops } = useShopContext();
   const [center, setCenter] = useState<GoogleMapCenterType>(defaultCenter);
 
@@ -49,6 +51,12 @@ const ShopSearch: FC = () => {
       <div className="w-1/3 overflow-auto">
         <div className="p-4 flex flex-col h-full">
           <SearchForm onSubmit={onSubmit} />
+          {isSignedIn && (
+            <div className="tabs justify-center items-center my-3">
+              <div className="tab tab-lg tab-bordered tab-active">すべて</div>
+              <div className="tab tab-lg tab-bordered">お気に入り</div>
+            </div>
+          )}
           {/* Google Place APIから取得した店舗情報をここに表示する */}
           <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
             {shops.length > 0 && shops.map((shop) => <ShopCard key={shop.place_id} shop={shop} />)}

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -2,11 +2,12 @@ import React, { FC, useEffect, useState } from "react";
 import axios from "axios";
 
 import GoogleMap from "../GoogleMap/GoogleMap";
-import { GoogleMapCenterType, InputSearchParams } from "../../types";
+import { GoogleMapCenterType, InputSearchParams, ShopType } from "../../types";
 import { useShopContext } from "../../context/ShopContext";
 import ShopCard from "./ShopCard";
 import SearchForm from "./SearchForm";
 import { useAuthContext } from "../../context/AuthContext";
+import { getAuthHeaders } from "../../utils/utils";
 
 const ShopSearch: FC = () => {
   // 名古屋をデフォルトの中心に設定
@@ -18,6 +19,13 @@ const ShopSearch: FC = () => {
   const { isSignedIn } = useAuthContext();
   const { shops, setShops } = useShopContext();
   const [center, setCenter] = useState<GoogleMapCenterType>(defaultCenter);
+
+  // タブの状態を管理するステート
+  const [tab, setTab] = useState<"all" | "bookmarks">("all");
+  // お気に入りのショップ情報を管理するステート
+  const [bookmarks, setBookmarks] = useState<ShopType[]>([]);
+
+  const headers = getAuthHeaders();
 
   useEffect(() => {
     if (shops.length > 0)
@@ -46,6 +54,24 @@ const ShopSearch: FC = () => {
     }
   };
 
+  // お気に入りのショップ情報を取得する関数
+  const getBookmarks = async () => {
+    try {
+      const res = await axios.get(`${process.env.REACT_APP_BACKEND_API_URL}/bookmarks`, {
+        headers,
+      });
+      setBookmarks(res.data);
+      console.log(res.data);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  // タブが変更されたときにお気に入りのショップ情報を取得する
+  useEffect(() => {
+    if (tab === "bookmarks") getBookmarks();
+  }, [tab]);
+
   return (
     <div className="flex h-screen">
       <div className="w-1/3 overflow-auto">
@@ -53,13 +79,19 @@ const ShopSearch: FC = () => {
           <SearchForm onSubmit={onSubmit} />
           {isSignedIn && (
             <div className="tabs justify-center items-center my-3">
-              <div className="tab tab-lg tab-bordered tab-active">すべて</div>
-              <div className="tab tab-lg tab-bordered">お気に入り</div>
+              <div className="tab tab-lg tab-bordered tab-active" onClick={() => setTab("all")}>
+                すべて
+              </div>
+              <div className="tab tab-lg tab-bordered" onClick={() => setTab("bookmarks")}>
+                お気に入り
+              </div>
             </div>
           )}
           {/* Google Place APIから取得した店舗情報をここに表示する */}
           <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
-            {shops.length > 0 && shops.map((shop) => <ShopCard key={shop.place_id} shop={shop} />)}
+            {(tab === "all" ? shops : bookmarks).map((shop) => (
+              <ShopCard key={shop.place_id} shop={shop} />
+            ))}
           </div>
         </div>
       </div>

--- a/front/src/hooks/useShopDetail.ts
+++ b/front/src/hooks/useShopDetail.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { ShopType } from "../types";
+
+// Places APIからショップの詳細情報を取得するカスタムフック
+export const useShopDetail = (id: string | undefined) => {
+  const [shopDetail, setShopDetail] = useState<ShopType>();
+
+  useEffect(() => {
+    const getShopDetail = async () => {
+      try {
+        const res = await axios.get(`${process.env.REACT_APP_BACKEND_API_URL}/shops/${id}`);
+        setShopDetail(res.data.result);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    getShopDetail();
+  }, []);
+
+  return shopDetail;
+};

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -23,6 +23,22 @@ export type User = {
   updated_at: Date;
 };
 
+export type RailsShopType = {
+  business_status?: string;
+  place_id: string;
+  name: string;
+  formatted_address: string;
+  photos: {
+    url: string;
+  };
+  geometry: {
+    location: {
+      lat: number;
+      lng: number;
+    };
+  };
+};
+
 export type ShopType = {
   business_status?: string;
   place_id: string;

--- a/front/src/utils/utils.ts
+++ b/front/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import Cookies from "js-cookie";
 
-// Place APIから取得した写真のURLを整形する関数
+// Places APIから取得した写真の参照を使用して画像のURLを作成する関数
 export const getPhotoUrl = (photoReference: string, maxWidth: number) => {
   const baseUrl = process.env.REACT_APP_GOOGLE_PLACE_PHOTO_URL;
   const apiKey = process.env.REACT_APP_GOOGLE_MAP_API_KEY;

--- a/front/src/utils/utils.ts
+++ b/front/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import Cookies from "js-cookie";
+
 // Place APIから取得した写真のURLを整形する関数
 export const getPhotoUrl = (photoReference: string, maxWidth: number) => {
   const baseUrl = process.env.REACT_APP_GOOGLE_PLACE_PHOTO_URL;
@@ -9,3 +11,10 @@ export const getPhotoUrl = (photoReference: string, maxWidth: number) => {
 export const formatAddress = (address: string) => {
   return address.replace(/日本、〒\d{3}-\d{4} /, "");
 };
+
+// 認証情報を取得する関数
+export const getAuthHeaders = () => ({
+  "access-token": Cookies.get("_access_token"),
+  client: Cookies.get("_client"),
+  uid: Cookies.get("_uid"),
+});


### PR DESCRIPTION
### 概要
ログイン時のみ、ショップ検索ページでブックマーク登録できるようにした。また、ショップ検索ページで「お気に入り」タブをクリックするとブックマークしたショップをカードで表示されるようになっている。もちろんカードをクリックしたらショップ詳細ページへ遷移するようになっている。
ショップの画像はgem 'carrierwave'を使ってアップロードしているが、shopsテーブル保存時に画像そのものではなく画像のURLを渡しているので注意！
shopsテーブルのデータは定期的（月1程度）に最新の情報に更新するようにしよう。

### 該当Issues
#25