### PR TITLE
アクセス制限とNOT FOUNDページの作成 + α

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,60 +1,17 @@
-import React, { useEffect } from "react";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import React from "react";
 
 import "./App.css";
-import Header from "./components/Header/Header";
-import Login from "./components/Login/Login";
-import Register from "./components/Register/Register";
-import TopPage from "./components/TopPage/TopPage";
-import { getCurrentUser } from "./lib/api/auth";
-import { AuthProvider, useAuthContext } from "./context/AuthContext";
-import ShopSearch from "./components/ShopSearch/ShopSearch";
+import { AuthProvider } from "./context/AuthContext";
 import { ShopProvider } from "./context/ShopContext";
-import ShopDetail from "./components/ShopDetail/ShopDetail";
+import AppRoutes from "./AppRoutes";
 
 const App = () => {
   return (
     <AuthProvider>
       <ShopProvider>
-        <AppContent />
+        <AppRoutes />
       </ShopProvider>
     </AuthProvider>
-  );
-};
-
-const AppContent = () => {
-  const { setIsSignedIn, setCurrentUser, setLoading } = useAuthContext();
-
-  // ログインしているユーザーの情報を取得
-  const handleGetCurrentUser = async () => {
-    try {
-      const res = await getCurrentUser();
-
-      if (res?.data.isLogin === true) {
-        setIsSignedIn(true);
-        setCurrentUser(res?.data.data);
-      }
-    } catch (e) {
-      console.log(e);
-    }
-    setLoading(false);
-  };
-
-  useEffect(() => {
-    handleGetCurrentUser();
-  }, [setCurrentUser]);
-
-  return (
-    <Router>
-      <Header />
-      <Routes>
-        <Route path="/" element={<TopPage />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="/shop-search" element={<ShopSearch />} />
-        <Route path="/shop-search/:id" element={<ShopDetail />} />
-      </Routes>
-    </Router>
   );
 };
 

--- a/front/src/AppRoutes.tsx
+++ b/front/src/AppRoutes.tsx
@@ -10,6 +10,7 @@ import { useAuthContext } from "./context/AuthContext";
 import ShopSearch from "./components/ShopSearch/ShopSearch";
 import ShopDetail from "./components/ShopDetail/ShopDetail";
 import PublicRoute from "./components/routes/PublicRoute";
+import PageNotFound from "./components/routes/PageNotFound";
 
 const AppRoutes = () => {
   const { setIsSignedIn, setCurrentUser, setLoading } = useAuthContext();
@@ -56,6 +57,7 @@ const AppRoutes = () => {
         />
         <Route path="/shop-search" element={<ShopSearch />} />
         <Route path="/shop-search/:id" element={<ShopDetail />} />
+        <Route path="*" element={<PageNotFound />} />
       </Routes>
     </Router>
   );

--- a/front/src/AppRoutes.tsx
+++ b/front/src/AppRoutes.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from "react";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import Header from "./components/Header/Header";
+import Login from "./components/Login/Login";
+import Register from "./components/Register/Register";
+import TopPage from "./components/TopPage/TopPage";
+import { getCurrentUser } from "./lib/api/auth";
+import { useAuthContext } from "./context/AuthContext";
+import ShopSearch from "./components/ShopSearch/ShopSearch";
+import ShopDetail from "./components/ShopDetail/ShopDetail";
+
+const AppRoutes = () => {
+  const { setIsSignedIn, setCurrentUser, setLoading } = useAuthContext();
+
+  // ログインしているユーザーの情報を取得
+  const handleGetCurrentUser = async () => {
+    try {
+      const res = await getCurrentUser();
+
+      if (res?.data.isLogin === true) {
+        setIsSignedIn(true);
+        setCurrentUser(res?.data.data);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    handleGetCurrentUser();
+  }, [setCurrentUser]);
+
+  return (
+    <Router>
+      <Header />
+      <Routes>
+        <Route path="/" element={<TopPage />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/shop-search" element={<ShopSearch />} />
+        <Route path="/shop-search/:id" element={<ShopDetail />} />
+      </Routes>
+    </Router>
+  );
+};
+
+export default AppRoutes;

--- a/front/src/AppRoutes.tsx
+++ b/front/src/AppRoutes.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+
 import Header from "./components/Header/Header";
 import Login from "./components/Login/Login";
 import Register from "./components/Register/Register";
@@ -8,6 +9,7 @@ import { getCurrentUser } from "./lib/api/auth";
 import { useAuthContext } from "./context/AuthContext";
 import ShopSearch from "./components/ShopSearch/ShopSearch";
 import ShopDetail from "./components/ShopDetail/ShopDetail";
+import PublicRoute from "./components/routes/PublicRoute";
 
 const AppRoutes = () => {
   const { setIsSignedIn, setCurrentUser, setLoading } = useAuthContext();
@@ -36,8 +38,22 @@ const AppRoutes = () => {
       <Header />
       <Routes>
         <Route path="/" element={<TopPage />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
+        <Route
+          path="/login"
+          element={
+            <PublicRoute>
+              <Login />
+            </PublicRoute>
+          }
+        />
+        <Route
+          path="/register"
+          element={
+            <PublicRoute>
+              <Register />
+            </PublicRoute>
+          }
+        />
         <Route path="/shop-search" element={<ShopSearch />} />
         <Route path="/shop-search/:id" element={<ShopDetail />} />
       </Routes>

--- a/front/src/components/Buttons/NeutralButton.tsx
+++ b/front/src/components/Buttons/NeutralButton.tsx
@@ -1,13 +1,13 @@
 import React, { FC } from "react";
 
 type Props = {
-  BTNTEXT: string;
+  buttonText: string;
 };
 
-const NeutralButton: FC<Props> = ({ BTNTEXT }) => {
+const NeutralButton: FC<Props> = ({ buttonText }) => {
   return (
     <button data-theme="valentine" className="btn btn-neutral">
-      {BTNTEXT}
+      {buttonText}
     </button>
   );
 };

--- a/front/src/components/Header/Header.tsx
+++ b/front/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC, memo, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { useAuthContext } from "../../context/AuthContext";
@@ -57,4 +57,4 @@ const Header: FC = () => {
   );
 };
 
-export default Header;
+export default memo(Header);

--- a/front/src/components/Login/Login.tsx
+++ b/front/src/components/Login/Login.tsx
@@ -41,7 +41,7 @@ const Login: FC = () => {
     }
   };
 
-  const BTNTEXT = "ログイン";
+  const buttonText = "ログイン";
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">
@@ -73,7 +73,7 @@ const Login: FC = () => {
             {errors.password && <span className="text-error">{errors.password.message}</span>}
           </div>
           <div className="flex justify-center">
-            <NeutralButton BTNTEXT={BTNTEXT} />
+            <NeutralButton buttonText={buttonText} />
           </div>
         </form>
       </div>

--- a/front/src/components/Register/Register.tsx
+++ b/front/src/components/Register/Register.tsx
@@ -40,7 +40,7 @@ const Register: FC = () => {
     }
   };
 
-  const BTNTEXT = "登録する";
+  const buttonText = "登録する";
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">
@@ -98,7 +98,7 @@ const Register: FC = () => {
             )}
           </div>
           <div className="flex justify-center">
-            <NeutralButton BTNTEXT={BTNTEXT} />
+            <NeutralButton buttonText={buttonText} />
           </div>
         </form>
       </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -10,10 +10,10 @@ import { useAuthContext } from "../../context/AuthContext";
 import { getAuthHeaders } from "../../utils/utils";
 
 const ShopSearch: FC = () => {
-  // 名古屋をデフォルトの中心に設定
+  // 東京を初期値としてマップの中心に設定
   const defaultCenter: GoogleMapCenterType = {
-    lat: 35.182253007459444,
-    lng: 136.90534328438358,
+    lat: 35.681236,
+    lng: 139.767125,
   };
 
   const { isSignedIn } = useAuthContext();

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -41,7 +41,6 @@ const ShopSearch: FC = () => {
         `${process.env.REACT_APP_BACKEND_API_URL}/shops/search?location=${data.search}`,
       );
       const results = res.data;
-      console.log(results);
       if (results.results.length > 0)
         setCenter({
           lat: results.results[0].geometry.location.lat,

--- a/front/src/components/TopPage/TopPage.tsx
+++ b/front/src/components/TopPage/TopPage.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { useAuthContext } from "../../context/AuthContext";
 
 const TopPage: FC = () => {
-  const BTNTEXT = "ログインして始める";
+  const buttonText = "ログインして始める";
   const { isSignedIn } = useAuthContext();
 
   return (
@@ -16,7 +16,7 @@ const TopPage: FC = () => {
         <p className="text-white text-2xl pb-5">お芋専門店を気軽に探せるアプリです</p>
         {!isSignedIn && (
           <Link to="/login">
-            <NeutralButton BTNTEXT={BTNTEXT} />
+            <NeutralButton buttonText={buttonText} />
           </Link>
         )}
       </div>

--- a/front/src/components/TopPage/TopPage.tsx
+++ b/front/src/components/TopPage/TopPage.tsx
@@ -4,7 +4,8 @@ import { Link } from "react-router-dom";
 import { useAuthContext } from "../../context/AuthContext";
 
 const TopPage: FC = () => {
-  const buttonText = "ログインして始める";
+  const beforeLoginButtonText = "ログインして始める";
+  const afterLoginButtonText = "お芋を探す";
   const { isSignedIn } = useAuthContext();
 
   return (
@@ -14,9 +15,13 @@ const TopPage: FC = () => {
       <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-center">
         <img src="/images/logo.png" alt="" />
         <p className="text-white text-2xl pb-5">お芋専門店を気軽に探せるアプリです</p>
-        {!isSignedIn && (
-          <Link to="/login">
-            <NeutralButton buttonText={buttonText} />
+        {isSignedIn ? (
+          <Link to="shop-search">
+            <NeutralButton buttonText={afterLoginButtonText} />
+          </Link>
+        ) : (
+          <Link to="login">
+            <NeutralButton buttonText={beforeLoginButtonText} />
           </Link>
         )}
       </div>

--- a/front/src/components/routes/PageNotFound.tsx
+++ b/front/src/components/routes/PageNotFound.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from "react";
+import { Link } from "react-router-dom";
+import NeutralButton from "../Buttons/NeutralButton";
+
+const PageNotFound: FC = () => {
+  const buttonText = "ホームへ戻る";
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen">
+      <h1 className="text-4xl font-bold">404</h1>
+      <p className="text-2xl mt-3 mb-8">お探しのページは見つかりませんでした。</p>
+      <Link to="/">
+        <NeutralButton buttonText={buttonText} />
+      </Link>
+    </div>
+  );
+};
+
+export default PageNotFound;

--- a/front/src/components/routes/PrivateRoute.tsx
+++ b/front/src/components/routes/PrivateRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate } from "react-router-dom";
+import { useAuthContext } from "../../context/AuthContext";
+import React, { FC } from "react";
+
+type RouteProps = {
+  children: React.ReactElement;
+};
+
+// ユーザーがログインしている場合にのみ特定のルートにアクセスを許可
+const PrivateRoute: FC<RouteProps> = ({ children }) => {
+  const { isSignedIn } = useAuthContext();
+
+  return isSignedIn ? children : <Navigate to="/login" />;
+};
+
+export default PrivateRoute;

--- a/front/src/components/routes/PublicRoute.tsx
+++ b/front/src/components/routes/PublicRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate } from "react-router-dom";
+import { useAuthContext } from "../../context/AuthContext";
+import React, { FC } from "react";
+
+type RouteProps = {
+  children: React.ReactElement;
+};
+
+// ユーザーがログインしている場合には特定のルートにアクセスを許可しない
+const PublicRoute: FC<RouteProps> = ({ children }) => {
+  const { isSignedIn } = useAuthContext();
+
+  return !isSignedIn ? children : <Navigate to="/" />;
+};
+
+export default PublicRoute;

--- a/front/src/context/AuthContext.tsx
+++ b/front/src/context/AuthContext.tsx
@@ -14,7 +14,7 @@ type AuthProviderProps = {
   children: React.ReactNode;
 };
 
-const AuthContext = createContext<AuthContextType>({} as AuthContextType);
+const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [loading, setLoading] = useState<boolean>(true);
@@ -36,4 +36,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   return <AuthContext.Provider value={AuthContextValue}>{children}</AuthContext.Provider>;
 };
 
-export const useAuthContext = () => useContext(AuthContext);
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+  if (context === null) throw new Error("useAuthContextはAuthProvider内で使用してください");
+
+  return context;
+};

--- a/front/src/context/ShopContext.tsx
+++ b/front/src/context/ShopContext.tsx
@@ -10,7 +10,7 @@ type ShopProviderProps = {
   children: React.ReactNode;
 };
 
-const ShopContext = createContext<ShopContextType>({} as ShopContextType);
+const ShopContext = createContext<ShopContextType | null>(null);
 
 export const ShopProvider = ({ children }: ShopProviderProps) => {
   const [shops, setShops] = useState<ShopType[]>([]);
@@ -23,4 +23,9 @@ export const ShopProvider = ({ children }: ShopProviderProps) => {
   return <ShopContext.Provider value={ShopContextValue}>{children}</ShopContext.Provider>;
 };
 
-export const useShopContext = () => useContext(ShopContext);
+export const useShopContext = () => {
+  const context = useContext(ShopContext);
+  if (context === null) throw new Error("useShopContextはShopProvider内で使用してください");
+
+  return context;
+};


### PR DESCRIPTION
### 概要
PublicRouteコンポーネントを作成し、ユーザーがログインしている場合、ユーザー新規登録・ログインページへのアクセスを禁止するようにした。今回はPublicRouteコンポーネントしか使ってないが、後にログインしていないユーザーへのアクセス制限も追加すると思いPrivateRouteコンポーネントも一緒に作成した。

NOT FOUNDページを作成し、NOT FOUNDページが表示されてもホームへ戻れるボタンを用意した。(NOT FOUNDページでもヘッダーは表示されているからボタンはいらないかもだけど)

ついでにずっと気になっていたヘッダーの再レンダリングをメモ化。ボタンのテキストを格納している変数名が分かりづらかったので適切な変数名に修正。あとはGoogleマップのcenterの初期値を名古屋から東京へ変更した。

### 該当Issues
#26