### PR TITLE
口コミとレーティングを閲覧できるモーダルの追加

### DIFF
--- a/api/app/controllers/api/v1/bookmarks_controller.rb
+++ b/api/app/controllers/api/v1/bookmarks_controller.rb
@@ -23,6 +23,6 @@ class Api::V1::BookmarksController < ApplicationController
   end
 
   def bookmark_params
-    params.require(:shop).permit(:place_id, :name, :formatted_address, :photos, :website)
+    params.require(:shop).permit(:place_id, :name, :formatted_address, :photos, :website, :latitude, :longitude, :rating, :user_ratings_total)
   end
 end

--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -5,8 +5,7 @@ class Api::V1::ShopsController < ApplicationController
 
   def search
     query = CGI.escape("さつまいも菓子専門店+in+#{params[:location]}")
-    fields = "formatted_address,name,geometry,place_id,photos"
-    uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/textsearch/json?query=#{query}&fields=#{fields}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
+    uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/textsearch/json?query=#{query}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
     res = Net::HTTP.get_response(uri)
     render json: res.body
   end

--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::ShopsController < ApplicationController
 
   def show
     plase_id = params[:id]
-    fields = "formatted_address,name,geometry,photos,current_opening_hours,website,place_id"
+    fields = "formatted_address,name,geometry,photos,current_opening_hours,website,place_id,reviews,rating,user_ratings_total"
     uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/details/json?place_id=#{plase_id}&fields=#{fields}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
     res = Net::HTTP.get_response(uri)
     render json: res.body

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -14,6 +14,10 @@ class Shop < ApplicationRecord
       shop.formatted_address = params[:formatted_address]
       shop.remote_photos_url = params[:photos]
       shop.website = params[:website]
+      shop.latitude = params[:latitude]
+      shop.longitude = params[:longitude]
+      shop.rating = params[:rating]
+      shop.user_ratings_total = params[:user_ratings_total]
     end
   end
 end

--- a/api/db/migrate/20230814122516_add_columns_to_shops.rb
+++ b/api/db/migrate/20230814122516_add_columns_to_shops.rb
@@ -1,0 +1,8 @@
+class AddColumnsToShops < ActiveRecord::Migration[7.0]
+  def change
+    add_column :shops, :latitude, :float
+    add_column :shops, :longitude, :float
+    add_column :shops, :rating, :float
+    add_column :shops, :user_ratings_total, :integer
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_080716) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_14_122516) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "shop_id", null: false
@@ -29,6 +29,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_080716) do
     t.string "website"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "latitude"
+    t.float "longitude"
+    t.float "rating"
+    t.integer "user_ratings_total"
     t.index ["place_id"], name: "index_shops_on_place_id", unique: true
   end
 

--- a/front/src/components/Rating/ShopRating.tsx
+++ b/front/src/components/Rating/ShopRating.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from "react";
+
+type ShopRatingProps = {
+  rating: number;
+  size?: "xs" | "sm" | "lg";
+};
+
+const ShopRating: FC<ShopRatingProps> = ({ rating, size = "md" }) => {
+  const fullStars = Math.floor(rating);
+  const halfStar = rating - fullStars >= 0.5;
+
+  return (
+    <div className={`rating rating-${size} rating-half pointer-events-none`}>
+      <input type="radio" className="rating-hidden" defaultChecked={rating < 0.5} />
+      {[...Array(10)].map((_, i) => (
+        <input
+          key={i}
+          type="radio"
+          name="rating-10"
+          className={`bg-amber-300 mask mask-star-2 ${i % 2 === 0 ? "mask-half-1" : "mask-half-2"}`}
+          defaultChecked={i < fullStars * 2 || (i === fullStars * 2 && halfStar)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ShopRating;

--- a/front/src/components/Rating/ShopRating.tsx
+++ b/front/src/components/Rating/ShopRating.tsx
@@ -6,13 +6,16 @@ type ShopRatingProps = {
 };
 
 const ShopRating: FC<ShopRatingProps> = ({ rating, size = "md" }) => {
+  const totalStars = 5;
+  const totalHalfStars = totalStars * 2;
+
   const fullStars = Math.floor(rating);
   const halfStar = rating - fullStars >= 0.5;
 
   return (
     <div className={`rating rating-${size} rating-half pointer-events-none`}>
       <input type="radio" className="rating-hidden" defaultChecked={rating < 0.5} />
-      {[...Array(10)].map((_, i) => (
+      {[...Array(totalHalfStars)].map((_, i) => (
         <input
           key={i}
           type="radio"

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -56,7 +56,16 @@ const ShopDetail: FC = () => {
       </div>
     );
 
-  const { place_id, name, formatted_address, website, photos, geometry } = shopDetail;
+  const {
+    place_id,
+    name,
+    formatted_address,
+    website,
+    photos,
+    geometry,
+    rating,
+    user_ratings_total,
+  } = shopDetail;
   const photoUrl = getPhotoUrl(photos[0].photo_reference, 400);
 
   const center: GoogleMapCenterType = {
@@ -73,6 +82,10 @@ const ShopDetail: FC = () => {
         formatted_address: formatted_address,
         photos: photoUrl,
         website: website,
+        latitude: geometry.location.lat,
+        longitude: geometry.location.lng,
+        rating: rating,
+        user_ratings_total: user_ratings_total,
       },
     };
     if (isBookmarked)

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -1,8 +1,10 @@
 import React, { FC } from "react";
 import { FaStar, FaRegStar } from "react-icons/fa";
+
 import { ShopType } from "../../types";
 import { formatAddress, getPhotoUrl } from "../../utils/utils";
 import { useAuthContext } from "../../context/AuthContext";
+import NeutralButton from "../Buttons/NeutralButton";
 
 type ShopInfoCardProps = {
   shopDetail: ShopType;
@@ -11,7 +13,16 @@ type ShopInfoCardProps = {
 };
 
 const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleBookmark }) => {
-  const { formatted_address, website, photos, current_opening_hours } = shopDetail;
+  const {
+    formatted_address,
+    website,
+    photos,
+    current_opening_hours,
+    rating,
+    user_ratings_total,
+    reviews,
+  } = shopDetail;
+
   const { isSignedIn } = useAuthContext();
   const address = formatAddress(formatted_address);
   const photoUrl = getPhotoUrl(photos[0].photo_reference, 400);
@@ -23,6 +34,23 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
         <div key={day} className="flex w-full">
           <div className="ml-16">
             {dayOfWeek}:　{time}
+          </div>
+        </div>
+      );
+    });
+  };
+
+  // 口コミを表示するカード
+  const reviewCards = () => {
+    if (!reviews || reviews.length === 0)
+      return <div className="flex items-start justify-center text-lg">口コミはありません</div>;
+
+    return reviews.map((review) => {
+      const { text, time } = review;
+      return (
+        <div className="card w-auto bg-base-100 shadow-xl card-bordered mb-5" key={time}>
+          <div className="card-body">
+            <p className="">{text}</p>
           </div>
         </div>
       );
@@ -73,6 +101,34 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
               ) : (
                 <div>ホームページが見つかりませんでした</div>
               )}
+            </div>
+            <div className="flex flex-col items-center mb-7">
+              <NeutralButton
+                buttonText="口コミを見る"
+                onClick={() => {
+                  if (document)
+                    (document.getElementById("shop_reviews") as HTMLFormElement).showModal();
+                }}
+              />
+              {/* 口コミを閲覧できるモーダル */}
+              <dialog id="shop_reviews" className="modal">
+                <form method="dialog" className="modal-box">
+                  <div className="flex justify-end mb-2">
+                    <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+                      ✕
+                    </button>
+                  </div>
+                  <div className="flex items-center justify-start">
+                    <div className="text-xl ">平均評価：{rating}</div>
+                    <div className="text-xl ml-4">総評価数：{user_ratings_total}</div>
+                  </div>
+                  <div className="divider"></div>
+                  <div className="flex flex-col items-center justify-center">{reviewCards()}</div>
+                </form>
+                <form method="dialog" className="modal-backdrop">
+                  <button>close</button>
+                </form>
+              </dialog>
             </div>
           </div>
         </div>

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -5,7 +5,7 @@ import { ShopType } from "../../types";
 import { formatAddress, getPhotoUrl } from "../../utils/utils";
 import { useAuthContext } from "../../context/AuthContext";
 import NeutralButton from "../Buttons/NeutralButton";
-import ShopRating from "../Rating/ShopRating";
+import ShopReviewsModal from "./ShopReviewsModal";
 
 type ShopInfoCardProps = {
   shopDetail: ShopType;
@@ -35,24 +35,6 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
         <div key={day} className="flex w-full">
           <div className="ml-16">
             {dayOfWeek}:　{time}
-          </div>
-        </div>
-      );
-    });
-  };
-
-  // 口コミを表示するカード
-  const reviewCards = () => {
-    if (!reviews || reviews.length === 0)
-      return <div className="flex items-start justify-center text-lg">口コミはありません</div>;
-
-    return reviews.map((review) => {
-      const { text, time, relative_time_description } = review;
-      return (
-        <div className="card w-auto bg-base-100 shadow-xl card-bordered mb-5" key={time}>
-          <div className="card-body">
-            <p className="">{text}</p>
-            <p className="text-deepRed text-sm mt-2">{`${relative_time_description}の口コミ`}</p>
           </div>
         </div>
       );
@@ -113,25 +95,11 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
                 }}
               />
               {/* 口コミを閲覧できるモーダル */}
-              <dialog id="shop_reviews" className="modal">
-                <form method="dialog" className="modal-box bg-creamLight">
-                  <div className="flex justify-end mb-2">
-                    <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
-                      ✕
-                    </button>
-                  </div>
-                  <div className="flex items-center justify-start">
-                    <div className="text-xl ">平均評価：{rating}</div>
-                    <ShopRating rating={rating} />
-                    <div className="text-xl ml-4">総評価数：{user_ratings_total}</div>
-                  </div>
-                  <div className="divider"></div>
-                  <div className="flex flex-col items-center justify-center">{reviewCards()}</div>
-                </form>
-                <form method="dialog" className="modal-backdrop">
-                  <button>close</button>
-                </form>
-              </dialog>
+              <ShopReviewsModal
+                rating={rating}
+                user_ratings_total={user_ratings_total}
+                reviews={reviews}
+              />
             </div>
           </div>
         </div>

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -57,6 +57,28 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
     });
   };
 
+  const shopRating = (rating: number) => {
+    const fullStars = Math.floor(rating);
+    const halfStar = rating - fullStars >= 0.5;
+
+    return (
+      <div className="rating rating-md rating-half pointer-events-none">
+        <input type="radio" className="rating-hidden" defaultChecked={rating < 0.5} />
+        {[...Array(10)].map((_, i) => (
+          <input
+            key={i}
+            type="radio"
+            name="rating-10"
+            className={`bg-amber-300 mask mask-star-2 ${
+              i % 2 === 0 ? "mask-half-1" : "mask-half-2"
+            }`}
+            defaultChecked={i < fullStars * 2 || (i === fullStars * 2 && halfStar)}
+          />
+        ))}
+      </div>
+    );
+  };
+
   return (
     <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
       <div className="card bg-base-100">
@@ -120,6 +142,7 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
                   </div>
                   <div className="flex items-center justify-start">
                     <div className="text-xl ">平均評価：{rating}</div>
+                    {shopRating(rating)}
                     <div className="text-xl ml-4">総評価数：{user_ratings_total}</div>
                   </div>
                   <div className="divider"></div>

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -112,7 +112,7 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
               />
               {/* 口コミを閲覧できるモーダル */}
               <dialog id="shop_reviews" className="modal">
-                <form method="dialog" className="modal-box">
+                <form method="dialog" className="modal-box bg-creamLight">
                   <div className="flex justify-end mb-2">
                     <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
                       ✕

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -46,11 +46,12 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
       return <div className="flex items-start justify-center text-lg">口コミはありません</div>;
 
     return reviews.map((review) => {
-      const { text, time } = review;
+      const { text, time, relative_time_description } = review;
       return (
         <div className="card w-auto bg-base-100 shadow-xl card-bordered mb-5" key={time}>
           <div className="card-body">
             <p className="">{text}</p>
+            <p className="text-deepRed text-sm mt-2">{`${relative_time_description}の口コミ`}</p>
           </div>
         </div>
       );

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -86,21 +86,23 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
                 <div>ホームページが見つかりませんでした</div>
               )}
             </div>
-            <div className="flex flex-col items-center mb-7">
-              <NeutralButton
-                buttonText="口コミを見る"
-                onClick={() => {
-                  if (document)
-                    (document.getElementById("shop_reviews") as HTMLFormElement).showModal();
-                }}
-              />
-              {/* 口コミを閲覧できるモーダル */}
-              <ShopReviewsModal
-                rating={rating}
-                user_ratings_total={user_ratings_total}
-                reviews={reviews}
-              />
-            </div>
+            {isSignedIn && (
+              <div className="flex flex-col items-center mb-7">
+                <NeutralButton
+                  buttonText="口コミを見る"
+                  onClick={() => {
+                    if (document)
+                      (document.getElementById("shop_reviews") as HTMLFormElement).showModal();
+                  }}
+                />
+                {/* 口コミを閲覧できるモーダル */}
+                <ShopReviewsModal
+                  rating={rating}
+                  user_ratings_total={user_ratings_total}
+                  reviews={reviews}
+                />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -5,6 +5,7 @@ import { ShopType } from "../../types";
 import { formatAddress, getPhotoUrl } from "../../utils/utils";
 import { useAuthContext } from "../../context/AuthContext";
 import NeutralButton from "../Buttons/NeutralButton";
+import ShopRating from "../Rating/ShopRating";
 
 type ShopInfoCardProps = {
   shopDetail: ShopType;
@@ -56,28 +57,6 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
         </div>
       );
     });
-  };
-
-  const shopRating = (rating: number) => {
-    const fullStars = Math.floor(rating);
-    const halfStar = rating - fullStars >= 0.5;
-
-    return (
-      <div className="rating rating-md rating-half pointer-events-none">
-        <input type="radio" className="rating-hidden" defaultChecked={rating < 0.5} />
-        {[...Array(10)].map((_, i) => (
-          <input
-            key={i}
-            type="radio"
-            name="rating-10"
-            className={`bg-amber-300 mask mask-star-2 ${
-              i % 2 === 0 ? "mask-half-1" : "mask-half-2"
-            }`}
-            defaultChecked={i < fullStars * 2 || (i === fullStars * 2 && halfStar)}
-          />
-        ))}
-      </div>
-    );
   };
 
   return (
@@ -143,7 +122,7 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
                   </div>
                   <div className="flex items-center justify-start">
                     <div className="text-xl ">平均評価：{rating}</div>
-                    {shopRating(rating)}
+                    <ShopRating rating={rating} />
                     <div className="text-xl ml-4">総評価数：{user_ratings_total}</div>
                   </div>
                   <div className="divider"></div>

--- a/front/src/components/ShopDetail/ShopReviewsModal.tsx
+++ b/front/src/components/ShopDetail/ShopReviewsModal.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from "react";
+import ShopRating from "../Rating/ShopRating";
+
+type ShopReviewsModalProps = {
+  rating: number;
+  user_ratings_total: number;
+  reviews?: {
+    text: string;
+    time: number;
+    relative_time_description: string;
+  }[];
+};
+
+const ShopReviewsModal: FC<ShopReviewsModalProps> = ({ rating, user_ratings_total, reviews }) => {
+  // 口コミを表示するカード
+  const reviewCards = () => {
+    if (!reviews || reviews.length === 0)
+      return <div className="flex items-start justify-center text-lg">口コミはありません</div>;
+
+    return reviews.map((review) => {
+      const { text, time, relative_time_description } = review;
+      return (
+        <div className="card w-auto bg-base-100 shadow-xl card-bordered mb-5" key={time}>
+          <div className="card-body">
+            <p className="">{text}</p>
+            <p className="text-deepRed text-sm mt-2">{`${relative_time_description}の口コミ`}</p>
+          </div>
+        </div>
+      );
+    });
+  };
+
+  return (
+    <dialog id="shop_reviews" className="modal">
+      <form method="dialog" className="modal-box bg-creamLight">
+        <div className="flex justify-end mb-2">
+          <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+        </div>
+        <div className="flex items-center justify-start">
+          <div className="text-xl ">平均評価：{rating}</div>
+          <ShopRating rating={rating} />
+          <div className="text-xl ml-4">総評価数：{user_ratings_total}</div>
+        </div>
+        <div className="divider"></div>
+        <div className="flex flex-col items-center justify-center">{reviewCards()}</div>
+      </form>
+      <form method="dialog" className="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  );
+};
+
+export default ShopReviewsModal;

--- a/front/src/components/ShopSearch/ShopCard.tsx
+++ b/front/src/components/ShopSearch/ShopCard.tsx
@@ -11,8 +11,8 @@ const ShopCard: FC<ShopCardProps> = ({ shop }) => {
   // お店が営業していない場合は表示しない
   if (shop.business_status && shop.business_status !== "OPERATIONAL") return null;
 
-  // ショップ情報が取得できない場合は表示しない
-  if (!shop) return null;
+  // ショップの写真が取得できない場合は表示しない
+  if (!shop.photos) return null;
 
   const navigate = useNavigate();
 

--- a/front/src/components/ShopSearch/ShopCard.tsx
+++ b/front/src/components/ShopSearch/ShopCard.tsx
@@ -8,34 +8,36 @@ type ShopCardProps = {
 };
 
 const ShopCard: FC<ShopCardProps> = ({ shop }) => {
+  const { business_status, formatted_address, name, photos, place_id } = shop;
+
   // お店が営業していない場合は表示しない
-  if (shop.business_status && shop.business_status !== "OPERATIONAL") return null;
+  if (business_status && business_status !== "OPERATIONAL") return null;
 
   // ショップの写真が取得できない場合は表示しない
-  if (!shop.photos) return null;
+  if (!photos) return null;
 
   const navigate = useNavigate();
 
-  const address = formatAddress(shop.formatted_address);
+  const address = formatAddress(formatted_address);
 
   // 画像URLを取得する
   let photoUrl;
-  if (Array.isArray(shop.photos))
+  if (Array.isArray(photos))
     // Google Place APIからのデータの場合
-    photoUrl = getPhotoUrl(shop.photos[0].photo_reference, 600);
+    photoUrl = getPhotoUrl(photos[0].photo_reference, 600);
   // RailsAPIからのデータの場合
-  else photoUrl = `${shop.photos.url}`;
+  else photoUrl = `${photos.url}`;
 
   return (
     <div
       key={shop.place_id}
       className="card w-88 bg-base-100 cursor-pointer"
-      onClick={() => navigate(`/shop-search/${shop.place_id}`)}
+      onClick={() => navigate(`/shop-search/${place_id}`)}
     >
       <div className="card-body">
         <div className="flex justify-between items-center">
-          <div className="flex-col ite">
-            <h2 className="card-title">{shop.name}</h2>
+          <div className="flex-col">
+            <h2 className="card-title">{name}</h2>
             <p>{address}</p>
           </div>
           <div className="items-center">

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -62,6 +62,12 @@ export type ShopType = {
     weekday_text: string[];
   };
   website?: string;
+  rating: number;
+  user_ratings_total: number;
+  reviews?: {
+    text: string;
+    time: number;
+  }[];
 };
 
 export type GoogleMapCenterType = {

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -67,6 +67,7 @@ export type ShopType = {
   reviews?: {
     text: string;
     time: number;
+    relative_time_description: string;
   }[];
 };
 

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
       colors: {
         deepRed: "#BA4B4D",
         reddishBrown: "#8a1f4a",
+        creamLight: "#f6f1e6",
       },
     },
   },


### PR DESCRIPTION
### 概要
ショップ詳細ページにてログイン時のみ、口コミとレーティングを閲覧できるモーダルを追加した。
shopsテーブルに緯度・経度・平均評価・総合評価を保存するためのカラムを追加し、ブックマーク時に追加したカラムにもデータが保存されるように修正。
またショップのリクエスト検索時に取得するフィールドを指定していたが、リクエスト検索時はフィールドを指定できないため該当コードを削除した。

### 該当Issue
#27 