### PR TITLE
Googleマップピンにショップの情報ウィンドウが表示される機能を追加

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -19,8 +19,7 @@ AllCops:
     - "tmp/**/*"
     - "vendor/**/*"
     - "lib/tasks/auto_annotate_models.rake"
-    - "config/environments/*"
-    - "config/puma.rb"
+    - "config/**/*"
 
 ### ルールのカスタマイズ
 
@@ -67,6 +66,10 @@ Style/SymbolArray:
 
 # 文字列による配列の%記法のチェック
 Style/WordArray:
+  Enabled: false
+
+#　ENV.fetch の使用を強制
+Style/FetchEnvVar:
   Enabled: false
 
 # 変数名に数字を許可

--- a/api/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/api/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,9 +1,7 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   def create
     super do |resource|
-      if resource.persisted?
-        sign_in(resource)
-      end
+      sign_in(resource) if resource.persisted?
     end
   end
 

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User

--- a/api/app/uploaders/avatar_uploader.rb
+++ b/api/app/uploaders/avatar_uploader.rb
@@ -14,7 +14,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
-  def default_url(*args)
+  def default_url(*)
     "https://potarecette-shop-images.s3.amazonaws.com/default_user_image.png"
   end
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -37,6 +37,7 @@
         "zod": "^3.21.4"
       },
       "devDependencies": {
+        "@types/googlemaps": "^3.43.3",
         "@types/js-cookie": "^3.0.3",
         "@types/react-toastify": "^4.1.0",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
@@ -4112,6 +4113,13 @@
       "version": "3.50.5",
       "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.50.5.tgz",
       "integrity": "sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw=="
+    },
+    "node_modules/@types/googlemaps": {
+      "version": "3.43.3",
+      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
+      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==",
+      "deprecated": "Types for the Google Maps browser API have moved to @types/google.maps. Note: these types are not for the googlemaps npm package, which is a Node API.",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",

--- a/front/package.json
+++ b/front/package.json
@@ -60,6 +60,7 @@
     ]
   },
   "devDependencies": {
+    "@types/googlemaps": "^3.43.3",
     "@types/js-cookie": "^3.0.3",
     "@types/react-toastify": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "^5.60.0",

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -1,13 +1,20 @@
-import React, { FC } from "react";
-import { GoogleMap as GoogleMapComponent, Marker, useJsApiLoader } from "@react-google-maps/api";
+import React, { FC, useState } from "react";
+import {
+  GoogleMap as GoogleMapComponent,
+  Marker,
+  useJsApiLoader,
+  InfoWindow,
+} from "@react-google-maps/api";
 
 import { GoogleMapCenterType } from "../../types";
 import { ShopType } from "../../types";
+import { formatAddress } from "../../utils/utils";
 
 type GoogleMapProps = {
   center: GoogleMapCenterType;
   zoom?: number;
   markers: ShopType[] | ShopType;
+  infoWindow?: boolean;
 };
 
 type ContentStyleType = {
@@ -20,18 +27,84 @@ const containerStyle: ContentStyleType = {
   height: "100%",
 };
 
-const GoogleMap: FC<GoogleMapProps> = ({ center, zoom, markers }) => {
+const GoogleMap: FC<GoogleMapProps> = ({ center, zoom, markers, infoWindow = false }) => {
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || "",
   });
 
+  const [selectedShop, setSelectedShop] = useState<ShopType | null>(null);
+
+  const defaultWindowContent = (shop: ShopType) => {
+    const address = formatAddress(shop.formatted_address);
+    return (
+      <>
+        <h2 className="text-center font-bold text-reddishBrown">{shop.name}</h2>
+        <div className="text-reddishBrown">住所</div>
+        <p className="text-xs mb-2">{address}</p>
+      </>
+    );
+  };
+
+  const renderWeekdays = (weekdayText: string[]) => {
+    return weekdayText.map((day) => {
+      return (
+        <p className="text-xs" key={day}>
+          {day}
+        </p>
+      );
+    });
+  };
+
+  const infoWindowContent = (shop: ShopType) => {
+    if (infoWindow)
+      return (
+        <div>
+          {defaultWindowContent(shop)}
+          <div className="text-reddishBrown">営業日時</div>
+          {shop.current_opening_hours && renderWeekdays(shop.current_opening_hours.weekday_text)}
+          <div className="text-reddishBrown mt-2">公式HP</div>
+          {shop.website && (
+            <a
+              href={shop.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link link-hover text-xs"
+            >
+              ホームページを閲覧する
+            </a>
+          )}
+        </div>
+      );
+    else return <div>{defaultWindowContent(shop)}</div>;
+  };
+
   return isLoaded ? (
     <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={zoom}>
       {Array.isArray(markers) ? (
-        markers.map((shop) => <Marker key={shop.place_id} position={shop.geometry.location} />)
+        markers.map((shop) => (
+          <Marker
+            key={shop.place_id}
+            position={shop.geometry.location}
+            onClick={() => setSelectedShop(shop)}
+          />
+        ))
       ) : (
-        <Marker key={markers.place_id} position={markers.geometry.location} />
+        <Marker
+          key={markers.place_id}
+          position={markers.geometry.location}
+          onClick={() => setSelectedShop(markers)}
+        />
+      )}
+
+      {selectedShop && (
+        <InfoWindow
+          position={selectedShop.geometry.location}
+          onCloseClick={() => setSelectedShop(null)}
+          options={{ pixelOffset: new window.google.maps.Size(0, -30) }}
+        >
+          {infoWindowContent(selectedShop)}
+        </InfoWindow>
       )}
     </GoogleMapComponent>
   ) : (

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -2,11 +2,12 @@ import React, { FC } from "react";
 import { GoogleMap as GoogleMapComponent, Marker, useJsApiLoader } from "@react-google-maps/api";
 
 import { GoogleMapCenterType } from "../../types";
-import { useShopContext } from "../../context/ShopContext";
+import { ShopType } from "../../types";
 
 type GoogleMapProps = {
   center: GoogleMapCenterType;
   zoom?: number;
+  markers: ShopType[] | ShopType;
 };
 
 type ContentStyleType = {
@@ -19,19 +20,19 @@ const containerStyle: ContentStyleType = {
   height: "100%",
 };
 
-const GoogleMap: FC<GoogleMapProps> = ({ center, zoom }) => {
+const GoogleMap: FC<GoogleMapProps> = ({ center, zoom, markers }) => {
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || "",
   });
 
-  const { shops } = useShopContext();
-
   return isLoaded ? (
     <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={zoom}>
-      {shops.map((shop) => (
-        <Marker key={shop.place_id} position={shop.geometry.location} />
-      ))}
+      {Array.isArray(markers) ? (
+        markers.map((shop) => <Marker key={shop.place_id} position={shop.geometry.location} />)
+      ) : (
+        <Marker key={markers.place_id} position={markers.geometry.location} />
+      )}
     </GoogleMapComponent>
   ) : (
     <></>

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -134,7 +134,9 @@ const ShopDetail: FC = () => {
             />
           </div>
         </div>
-        <div className="w-2/3 bg-white">{<GoogleMap center={center} zoom={15} />}</div>
+        <div className="w-2/3 bg-white">
+          {<GoogleMap center={center} zoom={15} markers={shopDetail} />}
+        </div>
       </div>
     </>
   ) : (

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -135,7 +135,7 @@ const ShopDetail: FC = () => {
           </div>
         </div>
         <div className="w-2/3 bg-white">
-          {<GoogleMap center={center} zoom={15} markers={shopDetail} />}
+          {<GoogleMap center={center} zoom={15} markers={shopDetail} infoWindow={true} />}
         </div>
       </div>
     </>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -103,7 +103,7 @@ const ShopSearch: FC = () => {
             </div>
           </div>
         </div>
-        <div className="w-2/3">{<GoogleMap center={center} zoom={11} />}</div>
+        <div className="w-2/3">{<GoogleMap center={center} zoom={11} markers={shops} />}</div>
       </div>
     </>
   );


### PR DESCRIPTION
### 概要
Googleマップ上に表示されているピンをクリックしたらショップの情報に関するウィンドウが表示されるようにした。propsとしてinfoWindow={true}を渡すことにより、ショップの検索ページと詳細ページでウィンドウの内容が切り替わるようにしてある。
またピンの位置をpropsとして渡すようにし、ショップ詳細ページでリロードしてもピンが消滅しないように修正を加えた。

Rubocopを実行したらいくつか指摘されたのでコードを修正。その際にENV.fetchの使用を強制するルールを無効にし、追加でconfig配下のファイルはRubocop実行の対象外にした。config関係のファイルはRubocopで修正したら対処できないエラーが発生する可能性を考慮したためである。

### 該当Issue
#35 