### PR TITLE
Fix: 口コミのテキストが空白でも表示されるバグを修正

### DIFF
--- a/front/src/components/ShopDetail/ShopReviewsModal.tsx
+++ b/front/src/components/ShopDetail/ShopReviewsModal.tsx
@@ -19,6 +19,7 @@ const ShopReviewsModal: FC<ShopReviewsModalProps> = ({ rating, user_ratings_tota
 
     return reviews.map((review) => {
       const { text, time, relative_time_description } = review;
+      if (text === "") return;
       return (
         <div className="card w-auto bg-base-100 shadow-xl card-bordered mb-5" key={time}>
           <div className="card-body">


### PR DESCRIPTION
口コミのテキストが空白でも表示されていたため、空白の場合はreturnするように修正を加えた。