### PR TITLE
Googleマップマーカーに関するバグの修正とshopsコントローラーのコードをリファクタ

### DIFF
--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ShopsController < ApplicationController
 
   def show
     plase_id = params[:id]
-    fields = "formatted_address,name,geometry,photos,current_opening_hours,website,place_id,reviews,rating,user_ratings_total"
+    fields = Shop::GOOGLE_MAP_FIELDS
     uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/details/json?place_id=#{plase_id}&fields=#{fields}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
     res = Net::HTTP.get_response(uri)
     render json: res.body

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -7,6 +7,9 @@ class Shop < ApplicationRecord
   validates :name, :formatted_address, :place_id, presence: true
   validates :place_id, uniqueness: true
 
+  # Google Places APIの検索結果から必要な情報を取得するための定数
+  GOOGLE_MAP_FIELDS = "formatted_address,name,geometry,photos,current_opening_hours,website,place_id,reviews,rating,user_ratings_total".freeze
+
   # 与えられたplace_idで店舗を検索し、存在しなければ新たに作成。
   def self.find_or_create_by_place(params)
     find_or_create_by(place_id: params[:place_id]) do |shop|

--- a/front/src/components/GoogleMap/GoogleMap.tsx
+++ b/front/src/components/GoogleMap/GoogleMap.tsx
@@ -82,13 +82,16 @@ const GoogleMap: FC<GoogleMapProps> = ({ center, zoom, markers, infoWindow = fal
   return isLoaded ? (
     <GoogleMapComponent mapContainerStyle={containerStyle} center={center} zoom={zoom}>
       {Array.isArray(markers) ? (
-        markers.map((shop) => (
-          <Marker
-            key={shop.place_id}
-            position={shop.geometry.location}
-            onClick={() => setSelectedShop(shop)}
-          />
-        ))
+        markers.map((shop) => {
+          if (shop.business_status === "OPERATIONAL")
+            return (
+              <Marker
+                key={shop.place_id}
+                position={shop.geometry.location}
+                onClick={() => setSelectedShop(shop)}
+              />
+            );
+        })
       ) : (
         <Marker
           key={markers.place_id}


### PR DESCRIPTION
### 概要
business_statusが"OPERATIONAL"の場合のみ、マーカーが表示されるように修正。
shopsコントローラーのフィールドを指定する変数はshopモデルで定数として定義し、shopsコントローラー内で呼び出すようにコードをリファクタリングした。

### 該当Issue
#47 