### PR TITLE
位置情報を使ったショップ検索機能を実装

### DIFF
--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -4,8 +4,16 @@ class Api::V1::ShopsController < ApplicationController
   require "cgi"
 
   def search
-    query = CGI.escape("さつまいも菓子専門店+in+#{params[:location]}")
-    uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/textsearch/json?query=#{query}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja")
+    if params[:location] =~ /^\d+\.\d+,\d+\.\d+$/ # 緯度経度の形式かどうかチェック
+      # 緯度経度が与えられた場合
+      query = CGI.escape("さつまいも菓子専門店")
+    else
+      # 地名や店名が与えられた場合
+      query = CGI.escape("さつまいも菓子専門店+in+#{params[:location]}")
+    end
+
+    radius = params[:radius] || 10000
+    uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/textsearch/json?query=#{query}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja&radius=#{radius}")
     res = Net::HTTP.get_response(uri)
     render json: res.body
   end

--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -4,15 +4,8 @@ class Api::V1::ShopsController < ApplicationController
   require "cgi"
 
   def search
-    if params[:location] =~ /^\d+\.\d+,\d+\.\d+$/ # 緯度経度の形式かどうかチェック
-      # 緯度経度が与えられた場合
-      query = CGI.escape("さつまいも菓子専門店")
-    else
-      # 地名や店名が与えられた場合
-      query = CGI.escape("さつまいも菓子専門店+in+#{params[:location]}")
-    end
-
-    radius = params[:radius] || 10000
+    query = Shop.generate_search_query(params[:location])
+    radius = params[:radius] || Shop::DEFAULT_RADIUS
     uri = URI.parse("#{ENV['GOOGLE_MAP_PLACE_URL']}/textsearch/json?query=#{query}&key=#{ENV['GOOGLE_MAP_API_KEY']}&language=ja&radius=#{radius}")
     res = Net::HTTP.get_response(uri)
     render json: res.body

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -10,6 +10,9 @@ class Shop < ApplicationRecord
   # Google Places APIの検索結果から必要な情報を取得するための定数
   GOOGLE_MAP_FIELDS = "formatted_address,name,geometry,photos,current_opening_hours,website,place_id,reviews,rating,user_ratings_total".freeze
 
+  # 検索時のデフォルトの範囲（半径）をメートル単位で定義
+  DEFAULT_RADIUS = 10000
+
   # 与えられたplace_idで店舗を検索し、存在しなければ新たに作成。
   def self.find_or_create_by_place(params)
     find_or_create_by(place_id: params[:place_id]) do |shop|
@@ -21,6 +24,15 @@ class Shop < ApplicationRecord
       shop.longitude = params[:longitude]
       shop.rating = params[:rating]
       shop.user_ratings_total = params[:user_ratings_total]
+    end
+  end
+
+  # 緯度経度または地名・店名を基にGoogle Places APIの検索クエリを生成
+  def self.generate_search_query(location)
+    if location =~ /^\d+\.\d+,\d+\.\d+$/
+      CGI.escape("さつまいも菓子専門店")
+    else
+      CGI.escape("さつまいも菓子専門店+in+#{location}")
     end
   end
 end

--- a/front/src/components/ShopSearch/SearchForm.tsx
+++ b/front/src/components/ShopSearch/SearchForm.tsx
@@ -25,7 +25,7 @@ const SearchForm: FC<SearchFormProps> = ({ onSubmit }) => {
         <div className="relative">
           <input
             type="text"
-            placeholder="検索"
+            placeholder="店舗名・住所で検索"
             className="input input-bordered w-full max-w-xs"
             {...register("search")}
           />

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -10,6 +10,7 @@ import { useAuthContext } from "../../context/AuthContext";
 import { getAuthHeaders } from "../../utils/utils";
 import PageHelmet from "../PageHelmet";
 import { toast } from "react-toastify";
+import NeutralButton from "../Buttons/NeutralButton";
 
 const ShopSearch: FC = () => {
   // 東京を初期値としてマップの中心に設定
@@ -55,6 +56,32 @@ const ShopSearch: FC = () => {
     }
   };
 
+  // 現在地からショップを検索する関数
+  const searchFromCurrentLocation = async () => {
+    if (navigator.geolocation)
+      navigator.geolocation.getCurrentPosition(async (position) => {
+        const latitude = position.coords.latitude;
+        const longitude = position.coords.longitude;
+
+        try {
+          const res = await axios.get(
+            `${process.env.REACT_APP_BACKEND_API_URL}/shops/search?location=${latitude},${longitude}`,
+          );
+          const results = res.data;
+          if (results.results.length > 0)
+            setCenter({
+              lat: results.results[0].geometry.location.lat,
+              lng: results.results[0].geometry.location.lng,
+            });
+
+          setShops(results.results);
+        } catch (e) {
+          toast.error("店舗情報の取得に失敗しました");
+        }
+      });
+    else toast.error("位置情報の取得に失敗しました。");
+  };
+
   // お気に入りのショップ情報を取得する関数
   const getBookmarks = async () => {
     try {
@@ -79,6 +106,9 @@ const ShopSearch: FC = () => {
         <div className="w-1/3 overflow-auto">
           <div className="p-4 flex flex-col h-full">
             <SearchForm onSubmit={onSubmit} />
+            <div className="flex items-center justify-center mt-4">
+              <NeutralButton buttonText="現在地から検索" onClick={searchFromCurrentLocation} />
+            </div>
             {isSignedIn && (
               <div className="tabs justify-center items-center my-3">
                 <div

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -106,7 +106,8 @@ const ShopSearch: FC = () => {
         <div className="w-1/3 overflow-auto">
           <div className="p-4 flex flex-col h-full">
             <SearchForm onSubmit={onSubmit} />
-            <div className="flex items-center justify-center mt-4">
+            <div className="divider px-16">OR</div>
+            <div className="flex items-center justify-center mb-2">
               <NeutralButton buttonText="現在地から検索" onClick={searchFromCurrentLocation} />
             </div>
             {isSignedIn && (


### PR DESCRIPTION
### 概要
ショップ検索ページに「現在地から検索」ボタンを追加し、ユーザーの現在地からショップを検索できるようにした。現在地から検索する場合のデフォルト検索範囲は半径10kmに設定し、パラメータでradiusを渡せば検索範囲を変更できるようにしてある。

### 該当Issue
#49 