### PR TITLE
ショップ検索ページ・詳細ページのレスポンシブデザインを実装

### DIFF
--- a/front/src/components/Login/Login.tsx
+++ b/front/src/components/Login/Login.tsx
@@ -46,7 +46,7 @@ const Login: FC = () => {
   return (
     <>
       <PageHelmet title="ログイン" />
-      <div className="flex flex-col items-center justify-center h-screen">
+      <div className="flex flex-col items-center h-screen mt-20">
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ログイン画面</h2>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/front/src/components/PasswordReset/PasswordReset.tsx
+++ b/front/src/components/PasswordReset/PasswordReset.tsx
@@ -54,14 +54,14 @@ const PasswordReset: FC = () => {
   return (
     <>
       <PageHelmet title="パスワードリセット" />
-      <div className="flex items-start justify-center mt-24">
+      <div className="flex items-start justify-center mt-20">
         <div className="card w-96 bg-white">
           <div className="card-body">
             <h2 className="card-title text-2xl mb-5 flex items-center justify-center">
               パスワード変更
             </h2>
             <form onSubmit={handleSubmit(onSubmit)}>
-              <div className="mb-3">
+              <div className="mb-2">
                 <label className="mb-2 text-sm" htmlFor="password">
                   パスワード
                 </label>
@@ -72,9 +72,9 @@ const PasswordReset: FC = () => {
                   placeholder="8文字以上で入力してください"
                   {...register("password")}
                 />
+                {errors.password && <span className="text-error">{errors.password.message}</span>}
               </div>
-              {errors.password && <span className="text-error">{errors.password.message}</span>}
-              <div className="mb-3">
+              <div className="mb-2">
                 <label className="mb-2 text-sm" htmlFor="passwordConfirmation">
                   パスワード（確認用）
                 </label>
@@ -84,10 +84,10 @@ const PasswordReset: FC = () => {
                   type="password"
                   {...register("passwordConfirmation")}
                 />
+                {errors.passwordConfirmation && (
+                  <span className="text-error">{errors.passwordConfirmation.message}</span>
+                )}
               </div>
-              {errors.passwordConfirmation && (
-                <span className="text-error">{errors.passwordConfirmation.message}</span>
-              )}
               <div className="card-actions justify-center">
                 <NeutralButton buttonText="パスワードを変更する" />
               </div>

--- a/front/src/components/Register/Register.tsx
+++ b/front/src/components/Register/Register.tsx
@@ -45,7 +45,7 @@ const Register: FC = () => {
   return (
     <>
       <PageHelmet title="ユーザー登録" />
-      <div className="flex flex-col items-center justify-center h-screen">
+      <div className="flex flex-col items-center mt-20">
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ユーザー登録画面</h2>
           <form onSubmit={handleSubmit(onSubmit)}>
@@ -105,7 +105,7 @@ const Register: FC = () => {
             </div>
           </form>
         </div>
-        <Link to="/login" className="mt-6 link link-hover">
+        <Link to="/login" className="mt-6 mb-10 link link-hover">
           すでにアカウントをお持ちの方はこちら
         </Link>
       </div>

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -108,19 +108,17 @@ const ShopDetail: FC = () => {
   return (
     <>
       <PageHelmet title={`${name}に関する詳細情報`} />
-      <div className="flex h-screen">
-        <div className="w-1/3 overflow-auto">
-          <div className="p-4 flex flex-col h-full">
-            <div className="flex items-center justify-center">
-              <Link to="/shop-search">
-                <div className="flex flex-row cursor-pointer">
-                  <MdOutlineArrowBackIos size={24} />
-                  <button className="mr-2">戻る</button>
-                </div>
-              </Link>
-              <div className="text-2xl font-bold">{name}</div>
-            </div>
-            {/* ここに店舗情報を表示 */}
+      <div className="flex flex-col overflow-auto lg:flex-row">
+        <div className="flex flex-col p-4 w-full lg:w-1/3">
+          <div className="flex items-center justify-between px-4">
+            <Link to="/shop-search" className="flex items-center">
+              <MdOutlineArrowBackIos size={24} />
+              <button className="ml-2">戻る</button>
+            </Link>
+            <div className="text-2xl font-bold text-center flex-grow">{name}</div>
+            <div className="w-[40px]"></div>
+          </div>
+          <div className="flex items-center justify-center flex-col lg:flex-row">
             <ShopInfoCard
               shopDetail={shopDetail}
               isBookmarked={isBookmarked}
@@ -128,7 +126,7 @@ const ShopDetail: FC = () => {
             />
           </div>
         </div>
-        <div className="w-2/3 bg-white">
+        <div className="p-4 h-[50vh] md:w-[80vh] md:mx-auto lg:p-0 lg:h-auto lg:w-2/3">
           {<GoogleMap center={center} zoom={15} markers={shopDetail} infoWindow={true} />}
         </div>
       </div>

--- a/front/src/components/ShopSearch/ShopCard.tsx
+++ b/front/src/components/ShopSearch/ShopCard.tsx
@@ -8,7 +8,8 @@ type ShopCardProps = {
 };
 
 const ShopCard: FC<ShopCardProps> = ({ shop }) => {
-  const { business_status, formatted_address, name, photos, place_id } = shop;
+  const { business_status, formatted_address, name, photos, place_id, rating, user_ratings_total } =
+    shop;
 
   // お店が営業していない場合は表示しない
   if (business_status && business_status !== "OPERATIONAL") return null;
@@ -38,7 +39,10 @@ const ShopCard: FC<ShopCardProps> = ({ shop }) => {
         <div className="flex justify-between items-center">
           <div className="flex-col">
             <h2 className="card-title">{name}</h2>
-            <p>{address}</p>
+            <div>{address}</div>
+            <p className="text-sm mt-2">
+              評価：{rating}（{user_ratings_total}件）
+            </p>
           </div>
           <div className="items-center">
             <div className="w-20 h-20 flex-shrink-0">

--- a/front/src/components/ShopSearch/ShopCard.tsx
+++ b/front/src/components/ShopSearch/ShopCard.tsx
@@ -31,7 +31,7 @@ const ShopCard: FC<ShopCardProps> = ({ shop }) => {
   return (
     <div
       key={shop.place_id}
-      className="card w-88 bg-base-100 cursor-pointer"
+      className="card w-96 bg-base-100 cursor-pointer"
       onClick={() => navigate(`/shop-search/${place_id}`)}
     >
       <div className="card-body">
@@ -41,7 +41,9 @@ const ShopCard: FC<ShopCardProps> = ({ shop }) => {
             <p>{address}</p>
           </div>
           <div className="items-center">
-            <img src={photoUrl} alt="" className="w-20 h-20" />
+            <div className="w-20 h-20 flex-shrink-0">
+              <img src={photoUrl} alt="" className="w-full h-full object-cover" />
+            </div>
           </div>
         </div>
       </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -106,39 +106,38 @@ const ShopSearch: FC = () => {
   return (
     <>
       <PageHelmet title="店舗検索" />
-      <div className="flex h-screen">
-        <div className="w-1/3 overflow-auto">
-          <div className="p-4 flex flex-col h-full">
+      <div className="flex flex-col h-screen lg:flex-row">
+        <div className="flex flex-col p-4 overflow-auto w-full lg:w-1/3">
+          <div className="flex items-center justify-center mb-3 lg:flex-col">
             <SearchForm onSubmit={onSubmit} />
-            <div className="divider px-16">OR</div>
-            <div className="flex items-center justify-center mb-2">
-              <NeutralButton buttonText="現在地から検索" onClick={searchFromCurrentLocation} />
-            </div>
-            {isSignedIn && (
-              <div className="tabs justify-center items-center my-3">
-                <div
-                  className={`tab tab-lg tab-bordered ${tab === "all" ? "tab-active" : ""}`}
-                  onClick={() => setTab("all")}
-                >
-                  すべて
-                </div>
-                <div
-                  className={`tab tab-lg tab-bordered ${tab === "bookmarks" ? "tab-active" : ""}`}
-                  onClick={() => setTab("bookmarks")}
-                >
-                  お気に入り
-                </div>
+            <div className="divider">OR</div>
+            <NeutralButton buttonText="現在地から検索" onClick={searchFromCurrentLocation} />
+          </div>
+          {isSignedIn && (
+            <div className="tabs justify-center items-center mb-3 flex">
+              <div
+                className={`tab tab-lg tab-bordered ${tab === "all" ? "tab-active" : ""}`}
+                onClick={() => setTab("all")}
+              >
+                すべて
               </div>
-            )}
-            {/* Google Place APIから取得した店舗情報をここに表示する */}
-            <div className="space-y-4 mt-4 w-full max-w-md overflow-auto">
-              {(tab === "all" ? shops : bookmarks).map((shop) => (
-                <ShopCard key={shop.place_id} shop={shop} />
-              ))}
+              <div
+                className={`tab tab-lg tab-bordered ${tab === "bookmarks" ? "tab-active" : ""}`}
+                onClick={() => setTab("bookmarks")}
+              >
+                お気に入り
+              </div>
             </div>
+          )}
+          <div className="flex flex-col items-center space-y-4 mt-4 overflow-auto h-[50vh] lg:h-auto">
+            {(tab === "all" ? shops : bookmarks).map((shop) => (
+              <ShopCard key={shop.place_id} shop={shop} />
+            ))}
           </div>
         </div>
-        <div className="w-2/3">{<GoogleMap center={center} zoom={11} markers={shops} />}</div>
+        <div className="h-[40%] w-[84%] px-4 pb-4 mx-auto lg:h-auto xl:w-2/3 lg:pb-0 lg:px-0 md:w-[60%]">
+          {<GoogleMap center={center} zoom={10} markers={shops} />}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
### 概要
ショップ検索ページと詳細ページのレスポンシブデザインを実装。ついでにショップ検索ページのカードに平均評価と総評価数を表示するようにしておいた。あとは細かい箇所のデザインを修正。

### 該当Issue
#46 