### PR TITLE
各ページのAPI通信時にローディングを表示するように修正

### DIFF
--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -33,13 +33,4 @@ class Shop < ApplicationRecord
       shop.user_ratings_total = params[:user_ratings_total]
     end
   end
-
-  # 緯度経度または地名・店名を基にGoogle Places APIの検索クエリを生成
-  def self.generate_search_query(location)
-    if location.match?(/^\d+\.\d+,\d+\.\d+$/)
-      CGI.escape("さつまいも菓子専門店")
-    else
-      CGI.escape("さつまいも菓子専門店+in+#{location}")
-    end
-  end
 end

--- a/api/app/services/google_maps_service.rb
+++ b/api/app/services/google_maps_service.rb
@@ -7,7 +7,7 @@ class GoogleMapsService
   LANGUAGE = 'ja'.freeze
 
   def self.search_shops_by_location(location)
-    query = Shop.generate_search_query(location)
+    query = CGI.escape("さつまいも菓子専門店+in+#{location}")
     uri = URI.parse("#{BASE_URL}/textsearch/json?query=#{query}&key=#{API_KEY}&language=#{LANGUAGE}")
     res = Net::HTTP.get_response(uri)
     res.body

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="https://www.potarecette.com/images/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="apple-touch-icon" href="https://www.potarecette.com/images/logo.png" />
+    <link rel="apple-touch-icon" href="https://www.potarecette.com/images/favicon.ico" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { ToastContainer } from "react-toastify";
-import "./App.css";
 import "react-toastify/dist/ReactToastify.css";
+import { HelmetProvider } from "react-helmet-async";
+
 import { AuthProvider } from "./context/AuthContext";
 import { ShopProvider } from "./context/ShopContext";
-import { HelmetProvider } from "react-helmet-async";
 import AppRoutes from "./AppRoutes";
 
 const App = () => {

--- a/front/src/components/Header/Header.tsx
+++ b/front/src/components/Header/Header.tsx
@@ -14,7 +14,7 @@ const Header: FC = () => {
   };
 
   return (
-    <div className="drawer drawer-end z-50">
+    <div className="drawer drawer-end z-20">
       <input
         type="checkbox"
         id="my-drawer"

--- a/front/src/components/Loadings/LoadingSpinner.tsx
+++ b/front/src/components/Loadings/LoadingSpinner.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 
 const LoadingSpinner: FC = () => {
   return createPortal(
-    <div className="fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
+    <div className="fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center z-30">
       <span className="loading loading-spinner loading-lg"></span>
     </div>,
     document.body,

--- a/front/src/components/Loadings/LoadingSpinner.tsx
+++ b/front/src/components/Loadings/LoadingSpinner.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from "react";
+import { createPortal } from "react-dom";
+
+const LoadingSpinner: FC = () => {
+  return createPortal(
+    <div className="fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
+      <span className="loading loading-spinner loading-lg"></span>
+    </div>,
+    document.body,
+  );
+};
+
+export default LoadingSpinner;

--- a/front/src/components/Login/Login.tsx
+++ b/front/src/components/Login/Login.tsx
@@ -11,6 +11,7 @@ import { login } from "../../lib/api/auth";
 import { useAuthContext } from "../../context/AuthContext";
 import PageHelmet from "../PageHelmet";
 import { toast } from "react-toastify";
+import LoadingSpinner from "../Loadings/LoadingSpinner";
 
 const Login: FC = () => {
   const {
@@ -48,12 +49,8 @@ const Login: FC = () => {
   return (
     <>
       <PageHelmet title="ログイン" />
+      {loading && <LoadingSpinner />}
       <div className="flex flex-col items-center h-screen mt-20">
-        {loading && (
-          <div className="absolute inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
-            <span className="loading loading-spinner loading-lg"></span>
-          </div>
-        )}
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ログイン画面</h2>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/front/src/components/Login/Login.tsx
+++ b/front/src/components/Login/Login.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -19,13 +19,14 @@ const Login: FC = () => {
     formState: { errors },
   } = useForm<LoginParams>({ resolver: zodResolver(loginValidationSchema) });
 
+  const [loading, setLoading] = useState<boolean>(false);
   const navigate = useNavigate();
   const { setIsSignedIn, setCurrentUser } = useAuthContext();
 
   const onSubmit = async (data: LoginParams) => {
+    setLoading(true);
     try {
       const res = await login(data);
-      // ログイン成功時にはCookieに各種情報を格納する
       if (res.status === 200) {
         Cookies.set("_access_token", res.headers["access-token"]);
         Cookies.set("_client", res.headers.client);
@@ -39,6 +40,7 @@ const Login: FC = () => {
     } catch (e) {
       toast.error("ログインに失敗しました。");
     }
+    setLoading(false);
   };
 
   const buttonText = "ログイン";
@@ -47,6 +49,11 @@ const Login: FC = () => {
     <>
       <PageHelmet title="ログイン" />
       <div className="flex flex-col items-center h-screen mt-20">
+        {loading && (
+          <div className="absolute inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
+            <span className="loading loading-spinner loading-lg"></span>
+          </div>
+        )}
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ログイン画面</h2>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/front/src/components/PasswordReset/PasswordReset.tsx
+++ b/front/src/components/PasswordReset/PasswordReset.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -9,6 +9,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import PageHelmet from "../PageHelmet";
 import NeutralButton from "../Buttons/NeutralButton";
 import { password, passwordConfirmation } from "../../utils/validationSchema";
+import LoadingSpinner from "../Loadings/LoadingSpinner";
 
 const PasswordReset: FC = () => {
   const passwordResetValidationSchema = z
@@ -23,6 +24,7 @@ const PasswordReset: FC = () => {
 
   type PasswordResetParams = z.infer<typeof passwordResetValidationSchema>;
 
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const params = new URLSearchParams(location.search);
@@ -38,6 +40,7 @@ const PasswordReset: FC = () => {
   });
 
   const onSubmit = async (data: PasswordResetParams) => {
+    setLoading(true);
     try {
       await axios.put(`${process.env.REACT_APP_BACKEND_API_URL}/auth/password`, {
         password: data.password,
@@ -49,11 +52,13 @@ const PasswordReset: FC = () => {
     } catch (e) {
       toast.error("パスワードの変更に失敗しました。");
     }
+    setLoading(false);
   };
 
   return (
     <>
       <PageHelmet title="パスワードリセット" />
+      {loading && <LoadingSpinner />}
       <div className="flex items-start justify-center mt-20">
         <div className="card w-96 bg-white">
           <div className="card-body">

--- a/front/src/components/Profile/Profile.tsx
+++ b/front/src/components/Profile/Profile.tsx
@@ -11,8 +11,10 @@ import NeutralButton from "../Buttons/NeutralButton";
 import { ProfileParams } from "../../types/index";
 import { getAuthHeaders } from "../../utils/utils";
 import ProfileEditModal from "./ProfileEditModal";
+import LoadingSpinner from "../Loadings/LoadingSpinner";
 
 const Profile: FC = () => {
+  const [loading, setLoading] = useState<boolean>(false);
   const { currentUser, setCurrentUser } = useAuthContext();
   const { name, email, image } = currentUser || {};
   const [previewImage, setPreviewImage] = useState<string | undefined>(image?.url);
@@ -25,12 +27,12 @@ const Profile: FC = () => {
 
   const onSubmit = async (data: ProfileParams) => {
     const headers = getAuthHeaders();
-
     const profileData = new FormData();
     profileData.append("user[name]", data.name);
     profileData.append("user[email]", data.email);
     if (data.image) profileData.append("user[image]", data.image);
-
+    closeModal();
+    setLoading(true);
     try {
       const res = await axios.put(`${process.env.REACT_APP_BACKEND_API_URL}/profile`, profileData, {
         headers,
@@ -45,8 +47,7 @@ const Profile: FC = () => {
     } catch (e) {
       toast.error("プロフィールの更新に失敗しました");
     }
-
-    closeModal();
+    setLoading(false);
   };
 
   // 選択した画像をプレビュー表示する関数
@@ -65,6 +66,7 @@ const Profile: FC = () => {
   return (
     <>
       <PageHelmet title={`${name}さんのプロフィール`} />
+      {loading && <LoadingSpinner />}
       <div className="flex items-center justify-center h-screen">
         <div className="card bg-base-100 shadow-xl">
           <div className="card-body mx-10">
@@ -97,7 +99,6 @@ const Profile: FC = () => {
               />
             </div>
 
-            {/* プロフィール編集モーダル */}
             <ProfileEditModal
               previewImage={previewImage}
               onSubmit={onSubmit}

--- a/front/src/components/Register/Register.tsx
+++ b/front/src/components/Register/Register.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -19,10 +19,12 @@ const Register: FC = () => {
     formState: { errors },
   } = useForm<SignUpParams>({ resolver: zodResolver(registerValidationSchema) });
 
+  const [loading, setLoading] = useState<boolean>(false);
   const navigate = useNavigate();
   const { setIsSignedIn, setCurrentUser } = useAuthContext();
 
   const onSubmit = async (data: SignUpParams) => {
+    setLoading(true);
     try {
       const res = await signUp(data);
       if (res.status === 200) {
@@ -38,6 +40,7 @@ const Register: FC = () => {
     } catch (e) {
       toast.error("ユーザー登録に失敗しました。");
     }
+    setLoading(false);
   };
 
   const buttonText = "登録する";
@@ -46,6 +49,11 @@ const Register: FC = () => {
     <>
       <PageHelmet title="ユーザー登録" />
       <div className="flex flex-col items-center mt-20">
+        {loading && (
+          <div className="absolute inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
+            <span className="loading loading-spinner loading-lg"></span>
+          </div>
+        )}
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ユーザー登録画面</h2>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/front/src/components/Register/Register.tsx
+++ b/front/src/components/Register/Register.tsx
@@ -11,6 +11,7 @@ import { signUp } from "../../lib/api/auth";
 import { useAuthContext } from "../../context/AuthContext";
 import PageHelmet from "../PageHelmet";
 import { toast } from "react-toastify";
+import LoadingSpinner from "../Loadings/LoadingSpinner";
 
 const Register: FC = () => {
   const {
@@ -48,12 +49,8 @@ const Register: FC = () => {
   return (
     <>
       <PageHelmet title="ユーザー登録" />
+      {loading && <LoadingSpinner />}
       <div className="flex flex-col items-center mt-20">
-        {loading && (
-          <div className="absolute inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
-            <span className="loading loading-spinner loading-lg"></span>
-          </div>
-        )}
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ユーザー登録画面</h2>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/front/src/components/ShopDetail/ShopDetail.tsx
+++ b/front/src/components/ShopDetail/ShopDetail.tsx
@@ -110,7 +110,7 @@ const ShopDetail: FC = () => {
       <PageHelmet title={`${name}に関する詳細情報`} />
       <div className="flex flex-col overflow-auto lg:flex-row">
         <div className="flex flex-col p-4 w-full lg:w-1/3">
-          <div className="flex items-center justify-between px-4">
+          <div className="flex items-center justify-between px-4 overflow-auto">
             <Link to="/shop-search" className="flex items-center">
               <MdOutlineArrowBackIos size={24} />
               <button className="ml-2">戻る</button>
@@ -118,7 +118,7 @@ const ShopDetail: FC = () => {
             <div className="text-2xl font-bold text-center flex-grow">{name}</div>
             <div className="w-[40px]"></div>
           </div>
-          <div className="flex items-center justify-center flex-col lg:flex-row">
+          <div className="flex flex-col items-center overflow-auto lg:h-screen">
             <ShopInfoCard
               shopDetail={shopDetail}
               isBookmarked={isBookmarked}
@@ -126,7 +126,7 @@ const ShopDetail: FC = () => {
             />
           </div>
         </div>
-        <div className="p-4 h-[50vh] md:w-[80vh] md:mx-auto lg:p-0 lg:h-auto lg:w-2/3">
+        <div className="p-4 h-[50vh] md:w-[100vh] md:mx-auto lg:p-0 lg:h-auto lg:w-2/3">
           {<GoogleMap center={center} zoom={15} markers={shopDetail} infoWindow={true} />}
         </div>
       </div>

--- a/front/src/components/ShopDetail/ShopInfoCard.tsx
+++ b/front/src/components/ShopDetail/ShopInfoCard.tsx
@@ -90,58 +90,55 @@ const ShopInfoCard: FC<ShopInfoCardProps> = ({ shopDetail, isBookmarked, handleB
               )}
             </div>
             {isSignedIn && (
-              <>
-                <div className="flex flex-col items-center mb-3">
-                  <NeutralButton
-                    buttonText="口コミを見る"
-                    onClick={() => {
-                      if (document)
-                        (document.getElementById("shop_reviews") as HTMLFormElement).showModal();
-                    }}
-                  />
-                  <ShopReviewsModal
-                    rating={rating}
-                    user_ratings_total={user_ratings_total}
-                    reviews={reviews}
-                  />
-                </div>
-
-                <div className="flex items-center justify-center">
-                  <details className="dropdown mb-7 z-10">
-                    <summary className="m-1 btn">SNSでシェア</summary>
-                    <ul className="p-2 shadow menu dropdown-content bg-base-100 rounded-box w-52">
-                      <li>
-                        <div className="text-gray-400 pointer-events-none">次でシェア：</div>
-                      </li>
-                      <li>
-                        <a
-                          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                            twitterShareText,
-                          )}&url=${window.location.href}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="link link-hover"
-                        >
-                          X（Twitter）
-                        </a>
-                      </li>
-                      <li>
-                        <a
-                          href={`https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(
-                            window.location.href,
-                          )}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="link link-hover"
-                        >
-                          LINE
-                        </a>
-                      </li>
-                    </ul>
-                  </details>
-                </div>
-              </>
+              <div className="flex flex-col items-center mb-3">
+                <NeutralButton
+                  buttonText="口コミを見る"
+                  onClick={() => {
+                    if (document)
+                      (document.getElementById("shop_reviews") as HTMLFormElement).showModal();
+                  }}
+                />
+                <ShopReviewsModal
+                  rating={rating}
+                  user_ratings_total={user_ratings_total}
+                  reviews={reviews}
+                />
+              </div>
             )}
+            <div className="flex items-center justify-center">
+              <details className="dropdown mb-7 z-10">
+                <summary className="m-1 btn">SNSでシェア</summary>
+                <ul className="p-2 shadow menu dropdown-content bg-base-100 rounded-box w-52">
+                  <li>
+                    <div className="text-gray-400 pointer-events-none">次でシェア：</div>
+                  </li>
+                  <li>
+                    <a
+                      href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
+                        twitterShareText,
+                      )}&url=${window.location.href}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="link link-hover"
+                    >
+                      X（Twitter）
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href={`https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(
+                        window.location.href,
+                      )}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="link link-hover"
+                    >
+                      LINE
+                    </a>
+                  </li>
+                </ul>
+              </details>
+            </div>
           </div>
         </div>
       </div>

--- a/front/src/components/ShopRankings/ShopRankingCard.tsx
+++ b/front/src/components/ShopRankings/ShopRankingCard.tsx
@@ -39,7 +39,7 @@ const ShopRankingCard: FC<ShopRankingCardProps> = ({ shop, index }) => {
       <div className="card-body items-center text-center mb-3">
         <div className="font-bold text-2xl mb-5">{name}</div>
         <div className="text-xl mb-2">{formatAddress(formatted_address)}</div>
-        <div className="flex items-center justify-start mb-3">
+        <div className="mb-3 sm:flex sm:items-center sm:justify-start">
           <div className="text-xl ">平均評価：{rating}</div>
           <div className="text-xl ml-4">総評価数：{user_ratings_total}件</div>
         </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -107,7 +107,7 @@ const ShopSearch: FC = () => {
     <>
       <PageHelmet title="店舗検索" />
       {loading && <LoadingSpinner />}
-      <div className="flex flex-col h-hull lg:h-screen lg:flex-row">
+      <div className="flex flex-col lg:h-screen lg:flex-row">
         <div className="flex flex-col p-4 overflow-auto w-full lg:w-1/3">
           <div className="flex flex-col items-center justify-center mb-3">
             <SearchForm onSubmit={onSubmit} />

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -107,11 +107,11 @@ const ShopSearch: FC = () => {
     <>
       <PageHelmet title="店舗検索" />
       {loading && <LoadingSpinner />}
-      <div className="flex flex-col h-screen lg:flex-row">
+      <div className="flex flex-col h-hull lg:h-screen lg:flex-row">
         <div className="flex flex-col p-4 overflow-auto w-full lg:w-1/3">
-          <div className="flex items-center justify-center mb-3 lg:flex-col">
+          <div className="flex flex-col items-center justify-center mb-3">
             <SearchForm onSubmit={onSubmit} />
-            <div className="divider">OR</div>
+            <div className="divider px-5 sm:px-20 md:px-28 lg:px-12">OR</div>
             <NeutralButton
               buttonText="現在地から検索"
               onClick={() => {
@@ -142,7 +142,7 @@ const ShopSearch: FC = () => {
             ))}
           </div>
         </div>
-        <div className="h-[40%] w-[84%] px-4 pb-4 mx-auto lg:h-auto xl:w-2/3 lg:pb-0 lg:px-0 md:w-[60%]">
+        <div className="p-4 h-[50vh] md:w-[100vh] md:mx-auto lg:p-0 lg:h-auto lg:w-2/3">
           {<GoogleMap center={center} zoom={10} markers={shops} />}
         </div>
       </div>


### PR DESCRIPTION
### 概要
各ページのAPI通信時にローディングを表示するように機能修正。ローディングスピナーはLoadingSpinnerコンポーネントに分離してある。

ログインしないとSNSシェアできないのは不便と感じたため、未ログイン時でもショップをシェアできるように変更。あとはショップ検索・詳細・ランキングページのレスポンシブデザインを一部修正した。

React側でユーザーの現在地を住所に変換後にRailsAPIへリクエスト送信するようにしたため、shopモデルに定義していたself.search_shops_by_locationメソッドを削除。ついでに使用していないファイルを削除した。

### 該当Issue
#74 