### PR TITLE
ショップ情報の更新処理を追加

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -45,6 +45,8 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog-aws'
 
+gem 'whenever', require: false
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
+    chronic (0.10.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -259,6 +260,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -284,6 +287,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   tzinfo-data
+  whenever
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/api/app/controllers/api/v1/shops_controller.rb
+++ b/api/app/controllers/api/v1/shops_controller.rb
@@ -8,7 +8,8 @@ class Api::V1::ShopsController < ApplicationController
   end
 
   def rankings
-    shops = Shop.ranked_by_bookmarks
+    shops = Shop.ranked_by_bookmarks.includes(:reviews)
+    shops = Shop.with_recent_reviews(shops)
     render json: shops.as_json(include: :reviews)
   end
 end

--- a/api/app/models/shop.rb
+++ b/api/app/models/shop.rb
@@ -15,12 +15,17 @@ class Shop < ApplicationRecord
   scope :ranked_by_bookmarks, lambda {
     select("shops.*, COUNT(bookmarks.id) AS bookmarks_count")
       .joins(:bookmarks)
-      .includes(:reviews)
       .where("shops.rating >= ?", 3.5)
       .group("shops.id")
       .order("bookmarks_count DESC")
       .limit(3)
   }
+
+  def self.with_recent_reviews(shops, limit = 5)
+    shops.each do |shop|
+      shop.reviews = shop.reviews.order(created_at: :desc).limit(limit)
+    end
+  end
 
   # 与えられたplace_idで店舗を検索し、存在しなければ新たに作成。
   def self.find_or_create_by_place(params)

--- a/api/config/schedule.rb
+++ b/api/config/schedule.rb
@@ -19,6 +19,6 @@
 
 # Learn more: http://github.com/javan/whenever
 
-every 2.weeks, at: '3:00 am' do
+every 1.weeks, at: '3:00 am' do
   rake 'update_shops:update'
 end

--- a/api/config/schedule.rb
+++ b/api/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every 2.weeks, at: '3:00 am' do
+  rake 'update_shops:update'
+end

--- a/api/lib/tasks/update_shops.rake
+++ b/api/lib/tasks/update_shops.rake
@@ -1,0 +1,22 @@
+namespace :update_shops do
+  desc "Google Place APIから店舗情報を更新"
+  task 店舗情報の更新: :environment do
+    Shop.find_each do |shop|
+      res_body = GoogleMapsService.get_shop_details(shop.place_id)
+      result = JSON.parse(res_body)["result"]
+
+      shop.update(
+        name: result["name"],
+        formatted_address: result["formatted_address"],
+        website: result['website'],
+        rating: result['rating'],
+        user_ratings_total: result['user_ratings_total']
+      )
+
+      result['reviews'].each do |google_review|
+        review = shop.reviews.find_or_initialize_by(time: google_review['time'])
+        review.save if review.new_record?
+      end
+    end
+  end
+end

--- a/api/lib/tasks/update_shops.rake
+++ b/api/lib/tasks/update_shops.rake
@@ -15,7 +15,11 @@ namespace :update_shops do
 
       result['reviews'].each do |google_review|
         review = shop.reviews.find_or_initialize_by(time: google_review['time'])
-        review.save if review.new_record?
+        if review.new_record?
+          review.save
+        else
+          shop.reviews.update(text: google_review['text'], relative_time_description: google_review['relative_time_description'])
+        end
       end
     end
   end

--- a/api/lib/tasks/update_shops.rake
+++ b/api/lib/tasks/update_shops.rake
@@ -1,24 +1,26 @@
 namespace :update_shops do
   desc "Google Place APIから店舗情報を更新"
   task update: :environment do
-    Shop.find_each do |shop|
-      res_body = GoogleMapsService.get_shop_details(shop.place_id)
-      result = JSON.parse(res_body)["result"]
+    if Date.today.monday?
+      Shop.find_each do |shop|
+        res_body = GoogleMapsService.get_shop_details(shop.place_id)
+        result = JSON.parse(res_body)["result"]
 
-      shop.update(
-        name: result["name"],
-        formatted_address: result["formatted_address"],
-        website: result['website'],
-        rating: result['rating'],
-        user_ratings_total: result['user_ratings_total']
-      )
+        shop.update(
+          name: result["name"],
+          formatted_address: result["formatted_address"],
+          website: result['website'],
+          rating: result['rating'],
+          user_ratings_total: result['user_ratings_total']
+        )
 
-      result['reviews'].each do |google_review|
-        review = shop.reviews.find_or_initialize_by(time: google_review['time'])
-        if review.new_record?
-          review.save
-        else
-          shop.reviews.update(text: google_review['text'], relative_time_description: google_review['relative_time_description'])
+        result['reviews'].each do |google_review|
+          review = shop.reviews.find_or_initialize_by(time: google_review['time'])
+          if review.new_record?
+            review.save
+          else
+            shop.reviews.update(text: google_review['text'], relative_time_description: google_review['relative_time_description'])
+          end
         end
       end
     end

--- a/api/lib/tasks/update_shops.rake
+++ b/api/lib/tasks/update_shops.rake
@@ -1,6 +1,6 @@
 namespace :update_shops do
   desc "Google Place APIから店舗情報を更新"
-  task 店舗情報の更新: :environment do
+  task update: :environment do
     Shop.find_each do |shop|
       res_body = GoogleMapsService.get_shop_details(shop.place_id)
       result = JSON.parse(res_body)["result"]


### PR DESCRIPTION
### 概要
Rakeタスクを作成し、DBに保存されているショップ情報と各ショップに紐づくレビューを更新する処理を追加。Herokuだとタスクの実行期間が最長でも毎日実行してしまうので、タスク内で月曜日のみ更新処理を実行するようにした。1週間に1回しか実行しないようにしAPI使用量を抑えている。

### 該当issue
#82 