### PR TITLE
パスワードの表示・非表示を切り替える機能を実装

### DIFF
--- a/front/src/components/Login/Login.tsx
+++ b/front/src/components/Login/Login.tsx
@@ -1,29 +1,17 @@
 import React, { FC, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import Cookies from "js-cookie";
-import { FaEye } from "react-icons/fa";
-import { FaEyeSlash } from "react-icons/fa";
 
-import { loginValidationSchema } from "../../utils/validationSchema";
-import NeutralButton from "../Buttons/NeutralButton";
 import { LoginParams } from "../../types/index";
 import { login } from "../../lib/api/auth";
 import { useAuthContext } from "../../context/AuthContext";
 import PageHelmet from "../PageHelmet";
 import { toast } from "react-toastify";
 import LoadingSpinner from "../Loadings/LoadingSpinner";
+import LoginForm from "./LoginForm";
 
 const Login: FC = () => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<LoginParams>({ resolver: zodResolver(loginValidationSchema) });
-
   const [loading, setLoading] = useState<boolean>(false);
-  const [isRevealPassword, setIsRevealPassword] = useState<boolean>(false);
   const navigate = useNavigate();
   const { setIsSignedIn, setCurrentUser } = useAuthContext();
 
@@ -47,12 +35,6 @@ const Login: FC = () => {
     setLoading(false);
   };
 
-  const buttonText = "ログイン";
-
-  const handleRevealPassword = () => {
-    setIsRevealPassword(!isRevealPassword);
-  };
-
   return (
     <>
       <PageHelmet title="ログイン" />
@@ -60,41 +42,7 @@ const Login: FC = () => {
       <div className="flex flex-col items-center h-screen mt-20">
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ログイン画面</h2>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <div className="mb-2">
-              <label className="mb-2 text-sm" htmlFor="email">
-                メールアドレス
-              </label>
-              <input
-                className="w-full px-3 py-2 border rounded-md outline-none"
-                id="email"
-                type="email"
-                {...register("email")}
-              />
-              {errors.email && <span className="text-error">{errors.email.message}</span>}
-            </div>
-            <div className="mb-5 relative">
-              <label className="mb-2 text-sm" htmlFor="password">
-                パスワード
-              </label>
-              <input
-                className="w-full px-3 py-2 border rounded-md outline-none"
-                id="password"
-                type={isRevealPassword ? "text" : "password"}
-                {...register("password")}
-              />
-              <span
-                onClick={handleRevealPassword}
-                className="absolute right-3 top-2/3 transform -translate-y-1/2"
-              >
-                {isRevealPassword ? <FaEyeSlash /> : <FaEye />}
-              </span>
-              {errors.password && <span className="text-error">{errors.password.message}</span>}
-            </div>
-            <div className="flex justify-center">
-              <NeutralButton buttonText={buttonText} />
-            </div>
-          </form>
+          <LoginForm onSubmit={onSubmit} />
         </div>
         <Link to="/password-reset-request" className="mt-6 link link-hover">
           パスワードをお忘れの方はこちら

--- a/front/src/components/Login/Login.tsx
+++ b/front/src/components/Login/Login.tsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Cookies from "js-cookie";
+import { FaEye } from "react-icons/fa";
+import { FaEyeSlash } from "react-icons/fa";
 
 import { loginValidationSchema } from "../../utils/validationSchema";
 import NeutralButton from "../Buttons/NeutralButton";
@@ -21,6 +23,7 @@ const Login: FC = () => {
   } = useForm<LoginParams>({ resolver: zodResolver(loginValidationSchema) });
 
   const [loading, setLoading] = useState<boolean>(false);
+  const [isRevealPassword, setIsRevealPassword] = useState<boolean>(false);
   const navigate = useNavigate();
   const { setIsSignedIn, setCurrentUser } = useAuthContext();
 
@@ -46,6 +49,10 @@ const Login: FC = () => {
 
   const buttonText = "ログイン";
 
+  const handleRevealPassword = () => {
+    setIsRevealPassword(!isRevealPassword);
+  };
+
   return (
     <>
       <PageHelmet title="ログイン" />
@@ -66,16 +73,22 @@ const Login: FC = () => {
               />
               {errors.email && <span className="text-error">{errors.email.message}</span>}
             </div>
-            <div className="mb-5">
+            <div className="mb-5 relative">
               <label className="mb-2 text-sm" htmlFor="password">
                 パスワード
               </label>
               <input
                 className="w-full px-3 py-2 border rounded-md outline-none"
                 id="password"
-                type="password"
+                type={isRevealPassword ? "text" : "password"}
                 {...register("password")}
               />
+              <span
+                onClick={handleRevealPassword}
+                className="absolute right-3 top-2/3 transform -translate-y-1/2"
+              >
+                {isRevealPassword ? <FaEyeSlash /> : <FaEye />}
+              </span>
               {errors.password && <span className="text-error">{errors.password.message}</span>}
             </div>
             <div className="flex justify-center">

--- a/front/src/components/Login/LoginForm.tsx
+++ b/front/src/components/Login/LoginForm.tsx
@@ -40,23 +40,27 @@ const LoginForm: FC<LoginFormProps> = ({ onSubmit }) => {
         />
         {errors.email && <span className="text-error">{errors.email.message}</span>}
       </div>
-      <div className="mb-5 relative">
+      <div className="mb-5">
         <label className="mb-2 text-sm" htmlFor="password">
           パスワード
         </label>
-        <input
-          className="w-full px-3 py-2 border rounded-md outline-none"
-          id="password"
-          type={isRevealPassword ? "text" : "password"}
-          {...register("password")}
-        />
-        <span
-          onClick={handleRevealPassword}
-          className="absolute right-3 top-2/3 transform -translate-y-1/2"
-        >
-          {isRevealPassword ? <FaEyeSlash /> : <FaEye />}
-        </span>
-        {errors.password && <span className="text-error">{errors.password.message}</span>}
+        <div className="relative">
+          <input
+            className="w-full px-3 py-2 border rounded-md outline-none"
+            id="password"
+            type={isRevealPassword ? "text" : "password"}
+            {...register("password")}
+          />
+          <span
+            onClick={handleRevealPassword}
+            className="absolute right-3 top-1/2 transform -translate-y-1/2"
+          >
+            {isRevealPassword ? <FaEyeSlash /> : <FaEye />}
+          </span>
+        </div>
+        <div className="h-5">
+          {errors.password && <span className="text-error">{errors.password.message}</span>}
+        </div>
       </div>
       <div className="flex justify-center">
         <NeutralButton buttonText={buttonText} />

--- a/front/src/components/Login/LoginForm.tsx
+++ b/front/src/components/Login/LoginForm.tsx
@@ -1,0 +1,68 @@
+import React, { FC, useState } from "react";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import NeutralButton from "../Buttons/NeutralButton";
+import { loginValidationSchema } from "../../utils/validationSchema";
+import { LoginParams } from "../../types/index";
+
+type LoginFormProps = {
+  onSubmit: (_data: LoginParams) => void; // eslint-disable-line no-unused-vars
+};
+
+const LoginForm: FC<LoginFormProps> = ({ onSubmit }) => {
+  const [isRevealPassword, setIsRevealPassword] = useState<boolean>(false);
+
+  const buttonText = "ログイン";
+
+  const handleRevealPassword = () => {
+    setIsRevealPassword(!isRevealPassword);
+  };
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginParams>({ resolver: zodResolver(loginValidationSchema) });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="mb-2">
+        <label className="mb-2 text-sm" htmlFor="email">
+          メールアドレス
+        </label>
+        <input
+          className="w-full px-3 py-2 border rounded-md outline-none"
+          id="email"
+          type="email"
+          {...register("email")}
+        />
+        {errors.email && <span className="text-error">{errors.email.message}</span>}
+      </div>
+      <div className="mb-5 relative">
+        <label className="mb-2 text-sm" htmlFor="password">
+          パスワード
+        </label>
+        <input
+          className="w-full px-3 py-2 border rounded-md outline-none"
+          id="password"
+          type={isRevealPassword ? "text" : "password"}
+          {...register("password")}
+        />
+        <span
+          onClick={handleRevealPassword}
+          className="absolute right-3 top-2/3 transform -translate-y-1/2"
+        >
+          {isRevealPassword ? <FaEyeSlash /> : <FaEye />}
+        </span>
+        {errors.password && <span className="text-error">{errors.password.message}</span>}
+      </div>
+      <div className="flex justify-center">
+        <NeutralButton buttonText={buttonText} />
+      </div>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/front/src/components/Register/Register.tsx
+++ b/front/src/components/Register/Register.tsx
@@ -1,25 +1,16 @@
 import React, { FC, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import Cookies from "js-cookie";
 
-import { registerValidationSchema } from "../../utils/validationSchema";
-import NeutralButton from "../Buttons/NeutralButton";
 import { SignUpParams } from "../../types";
 import { signUp } from "../../lib/api/auth";
 import { useAuthContext } from "../../context/AuthContext";
 import PageHelmet from "../PageHelmet";
 import { toast } from "react-toastify";
 import LoadingSpinner from "../Loadings/LoadingSpinner";
+import RegisterForm from "./RegisterForm";
 
 const Register: FC = () => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<SignUpParams>({ resolver: zodResolver(registerValidationSchema) });
-
   const [loading, setLoading] = useState<boolean>(false);
   const navigate = useNavigate();
   const { setIsSignedIn, setCurrentUser } = useAuthContext();
@@ -44,8 +35,6 @@ const Register: FC = () => {
     setLoading(false);
   };
 
-  const buttonText = "登録する";
-
   return (
     <>
       <PageHelmet title="ユーザー登録" />
@@ -53,62 +42,7 @@ const Register: FC = () => {
       <div className="flex flex-col items-center mt-20">
         <div className="w-96 bg-white rounded p-6 shadow-xl">
           <h2 className="text-2xl text-center font-bold mb-5 text-gray-800">ユーザー登録画面</h2>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <div className="mb-2">
-              <label className="mb-2 text-sm" htmlFor="name">
-                ユーザー名
-              </label>
-              <input
-                className="w-full px-3 py-2 border rounded-md outline-none"
-                id="name"
-                type="text"
-                {...register("name")}
-              />
-              {errors.name && <span className="text-error">{errors.name.message}</span>}
-            </div>
-            <div className="mb-2">
-              <label className="mb-2 text-sm" htmlFor="email">
-                メールアドレス
-              </label>
-              <input
-                className="w-full px-3 py-2 border rounded-md outline-none"
-                id="email"
-                type="email"
-                {...register("email")}
-              />
-              {errors.email && <span className="text-error">{errors.email.message}</span>}
-            </div>
-            <div className="mb-2">
-              <label className="mb-2 text-sm" htmlFor="password">
-                パスワード
-              </label>
-              <input
-                className="w-full px-3 py-2 border rounded-md outline-none"
-                id="password"
-                type="password"
-                placeholder="8文字以上で入力してください"
-                {...register("password")}
-              />
-              {errors.password && <span className="text-error">{errors.password.message}</span>}
-            </div>
-            <div className="mb-5">
-              <label className="mb-2 text-sm" htmlFor="passwordConfirmation">
-                パスワード（確認用）
-              </label>
-              <input
-                className="w-full px-3 py-2 border rounded-md outline-none"
-                id="passwordConfirmation"
-                type="password"
-                {...register("passwordConfirmation")}
-              />
-              {errors.passwordConfirmation && (
-                <span className="text-error">{errors.passwordConfirmation.message}</span>
-              )}
-            </div>
-            <div className="flex justify-center">
-              <NeutralButton buttonText={buttonText} />
-            </div>
-          </form>
+          <RegisterForm onSubmit={onSubmit} />
         </div>
         <Link to="/login" className="mt-6 mb-10 link link-hover">
           すでにアカウントをお持ちの方はこちら

--- a/front/src/components/Register/RegisterForm.tsx
+++ b/front/src/components/Register/RegisterForm.tsx
@@ -1,0 +1,82 @@
+import React, { FC } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { SignUpParams } from "../../types";
+import NeutralButton from "../Buttons/NeutralButton";
+import { registerValidationSchema } from "../../utils/validationSchema";
+
+type RegisterFormProps = {
+  onSubmit: (_data: SignUpParams) => void; // eslint-disable-line no-unused-vars
+};
+
+const RegisterForm: FC<RegisterFormProps> = ({ onSubmit }) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignUpParams>({ resolver: zodResolver(registerValidationSchema) });
+
+  const buttonText = "登録する";
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="mb-2">
+        <label className="mb-2 text-sm" htmlFor="name">
+          ユーザー名
+        </label>
+        <input
+          className="w-full px-3 py-2 border rounded-md outline-none"
+          id="name"
+          type="text"
+          {...register("name")}
+        />
+        {errors.name && <span className="text-error">{errors.name.message}</span>}
+      </div>
+      <div className="mb-2">
+        <label className="mb-2 text-sm" htmlFor="email">
+          メールアドレス
+        </label>
+        <input
+          className="w-full px-3 py-2 border rounded-md outline-none"
+          id="email"
+          type="email"
+          {...register("email")}
+        />
+        {errors.email && <span className="text-error">{errors.email.message}</span>}
+      </div>
+      <div className="mb-2">
+        <label className="mb-2 text-sm" htmlFor="password">
+          パスワード
+        </label>
+        <input
+          className="w-full px-3 py-2 border rounded-md outline-none"
+          id="password"
+          type="password"
+          placeholder="8文字以上で入力してください"
+          {...register("password")}
+        />
+        {errors.password && <span className="text-error">{errors.password.message}</span>}
+      </div>
+      <div className="mb-5">
+        <label className="mb-2 text-sm" htmlFor="passwordConfirmation">
+          パスワード（確認用）
+        </label>
+        <input
+          className="w-full px-3 py-2 border rounded-md outline-none"
+          id="passwordConfirmation"
+          type="password"
+          {...register("passwordConfirmation")}
+        />
+        {errors.passwordConfirmation && (
+          <span className="text-error">{errors.passwordConfirmation.message}</span>
+        )}
+      </div>
+      <div className="flex justify-center">
+        <NeutralButton buttonText={buttonText} />
+      </div>
+    </form>
+  );
+};
+
+export default RegisterForm;


### PR DESCRIPTION
### 概要
ログインページのパスワード入力欄に目のアイコンを配置し、クリックするとパスワードの表示方法を切り替えれるようにした。

ついでにLogin.tsxとRegister.tsxファイルのリファクタリングを実施。フォームにあたる部分のコードをコンポーネントとして切り分けた。

### 該当Issue
#101 