### PR TITLE
ショップ検索結果がない場合はメッセージを表示するように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -40,5 +40,6 @@
 # uploader
 /public/uploads/
 
-# rspec
+/.DS_Store
+/app/.DS_Store
 /spec/.DS_Store

--- a/front/src/components/ShopSearch/ShopCard.tsx
+++ b/front/src/components/ShopSearch/ShopCard.tsx
@@ -38,13 +38,13 @@ const ShopCard: FC<ShopCardProps> = ({ shop }) => {
       <div className="card-body">
         <div className="flex justify-between items-center">
           <div className="flex-col">
-            <h2 className="card-title">{name}</h2>
-            <div>{address}</div>
+            <h2 className="card-title text-lg">{name}</h2>
+            <div className="text-sm mt-2">{address}</div>
             <p className="text-sm mt-2">
               評価：{rating}（{user_ratings_total}件）
             </p>
           </div>
-          <div className="items-center">
+          <div className="items-center ml-1">
             <div className="w-20 h-20 flex-shrink-0">
               <img src={photoUrl} alt="" className="w-full h-full object-cover" />
             </div>

--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -51,6 +51,9 @@ const ShopSearch: FC = () => {
           lng: results.results[0].geometry.location.lng,
         });
         setShops(results.results);
+      } else {
+        setShops([]);
+        setCenter(defaultCenter);
       }
     } catch (e) {
       toast.error("店舗情報の取得に失敗しました");
@@ -98,6 +101,12 @@ const ShopSearch: FC = () => {
     }
   };
 
+  const shopCardList = () => {
+    return (tab === "all" ? shops : bookmarks).map((shop) => (
+      <ShopCard key={shop.place_id} shop={shop} />
+    ));
+  };
+
   // タブが変更されたときにお気に入りのショップ情報を取得する
   useEffect(() => {
     if (tab === "bookmarks") getBookmarks();
@@ -137,9 +146,11 @@ const ShopSearch: FC = () => {
             </div>
           )}
           <div className="flex flex-col items-center space-y-4 mt-4 overflow-auto h-[50vh] lg:h-auto">
-            {(tab === "all" ? shops : bookmarks).map((shop) => (
-              <ShopCard key={shop.place_id} shop={shop} />
-            ))}
+            {shops.length > 0 ? (
+              shopCardList()
+            ) : (
+              <p className="text-lg opacity-70 sm:text-xl">検索結果がありません</p>
+            )}
           </div>
         </div>
         <div className="p-4 h-[50vh] md:w-[100vh] md:mx-auto lg:p-0 lg:h-auto lg:w-2/3">


### PR DESCRIPTION
### 概要
ショップ検索結果がない場合は、ショップカードを表示する箇所に「検索結果がありません」と表示するように修正を行った。これにより検索結果がないことがユーザーに伝わりやすくなった。

### 該当Issue
#103 