### PR TITLE
現在地検索で付近のお店が取得できないバグを修正

### DIFF
--- a/front/src/components/ShopSearch/ShopSearch.tsx
+++ b/front/src/components/ShopSearch/ShopSearch.tsx
@@ -71,7 +71,8 @@ const ShopSearch: FC = () => {
       const res = await axios.get(
         `${process.env.REACT_APP_GOOGLE_MAP_BASE_URL}/geocode/json?latlng=${latitude},${longitude}&key=${process.env.REACT_APP_GOOGLE_MAP_API_KEY}&language=ja`,
       );
-      return res.data.plus_code.compound_code;
+      const address = res.data.plus_code.compound_code.split(" ")[1];
+      return address;
     } catch (e) {
       toast.error("住所の取得に失敗しました");
       return null;


### PR DESCRIPTION
### 概要
緯度経度から住所を取得する関数内でレスポンスのcompound_codeを返却値に入れているのだが、このcompound_codeの値に不要な文字列が含まれた状態でreturn文で返却していたことが原因だった。そのためcompound_codeから取得した文字列を空白スペースで分割し、不要な文字列を排除して返却するように修正を行った。

### 概要Issue
#107 